### PR TITLE
Improvements to closed-loop handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Added 6D loop contacts to account for contacts between parts of the robot in https://github.com/loco-3d/crocoddyl/pull/1309
 * Fixed the inequality constraints' feasibility computation by incorporating bounds into the calculation in https://github.com/loco-3d/crocoddyl/pull/1307
 * Improved the action factory used for unit testing in https://github.com/loco-3d/crocoddyl/pull/1300
 * Ignore ruff issues in ipython notebook files in https://github.com/loco-3d/crocoddyl/pull/1297

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -134,11 +134,6 @@ void exposeContact6DLoop() {
                                     bp::return_internal_reference<>()),
                     "Jacobian of the spatial acceleration of the first contact "
                     "frame wrt v")
-      .add_property("a1_partial_da",
-                    bp::make_getter(&ContactData6DLoop::a1_partial_da,
-                                    bp::return_internal_reference<>()),
-                    "Jacobian of the spatial acceleration of the first contact "
-                    "frame wrt a")
       .add_property(
           "v2_partial_dq",
           bp::make_getter(&ContactData6DLoop::v2_partial_dq,
@@ -154,11 +149,6 @@ void exposeContact6DLoop() {
                                     bp::return_internal_reference<>()),
                     "Jacobian of the spatial acceleration of the second "
                     "contact frame wrt v")
-      .add_property("a2_partial_da",
-                    bp::make_getter(&ContactData6DLoop::a2_partial_da,
-                                    bp::return_internal_reference<>()),
-                    "Jacobian of the spatial acceleration of the second "
-                    "contact frame wrt a")
       .add_property("da0_dx",
                     bp::make_getter(&ContactData6DLoop::da0_dx,
                                     bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -226,6 +226,18 @@ void exposeContact6DLoop() {
           bp::make_getter(&ContactData6DLoop::f1af2,
                           bp::return_internal_reference<>()),
           "Acceleration of the second contact frame in the first contact frame")
+      .add_property("f_cross",
+                    bp::make_getter(&ContactData6DLoop::f_cross,
+                                    bp::return_internal_reference<>()),
+                    "Cross product matrix")
+      .add_property("joint1_f",
+                    bp::make_getter(&ContactData6DLoop::joint1_f,
+                                    bp::return_internal_reference<>()),
+                    "Force at the first joint")
+      .add_property("joint2_f",
+                    bp::make_getter(&ContactData6DLoop::joint2_f,
+                                    bp::return_internal_reference<>()),
+                    "Force at the second joint")
       .def(CopyableVisitor<ContactData6DLoop>());
 }
 

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -224,10 +224,6 @@ void exposeContact6DLoop() {
           bp::make_getter(&ContactData6DLoop::f1af2,
                           bp::return_internal_reference<>()),
           "Acceleration of the second contact frame in the first contact frame")
-      .add_property("f_cross",
-                    bp::make_getter(&ContactData6DLoop::f_cross,
-                                    bp::return_internal_reference<>()),
-                    "Cross product matrix")
       .add_property("joint1_f",
                     bp::make_getter(&ContactData6DLoop::joint1_f,
                                     bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -34,12 +34,15 @@ void exposeContact6DLoop() {
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param joint1_id: Parent joint id of the first contact frame\n"
-          ":param joint1_placement: Placement of the first contact frame with respect to the parent joint\n"
+          ":param joint1_placement: Placement of the first contact frame with "
+          "respect to the parent joint\n"
           ":param joint2_id: Parent joint id of the second contact frames\n"
-          ":param joint2_placement: Placement of the second contact frame with respect to the parent joint\n"
+          ":param joint2_placement: Placement of the second contact frame with "
+          "respect to the parent joint\n"
           ":param ref: reference frame of contact (must be pinocchio::LOCAL)\n"
           ":param nu: dimension of control vector\n"
-          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
+          ":param gains: gains of the contact model (default "
+          "np.matrix([0.,0.]))"))
       .def("calc", &ContactModel6DLoop::calc, bp::args("self", "data", "x"),
            "Compute the 6D loop-contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic "
@@ -49,7 +52,8 @@ void exposeContact6DLoop() {
            ":param x: state point (dim. state.nx)")
       .def("calcDiff", &ContactModel6DLoop::calcDiff,
            bp::args("self", "data", "x"),
-           "Compute the derivatives of the 6D loop-contact holonomic constraint.\n\n"
+           "Compute the derivatives of the 6D loop-contact holonomic "
+           "constraint.\n\n"
            "The rigid contact model throught acceleration-base holonomic "
            "constraint\n"
            "of the contact frame placement.\n"
@@ -62,11 +66,11 @@ void exposeContact6DLoop() {
            ":param data: cost data\n"
            ":param force: force vector (dimension 6)")
       .def("updateForceDiff", &ContactModel6DLoop::updateForceDiff,
-              bp::args("self", "data", "df_dx", "df_du"),
-              "Update the force derivatives.\n\n"
-              ":param data: cost data\n"
-              ":param df_dx: Jacobian of the force with respect to the state\n"
-              ":param df_du: Jacobian of the force with respect to the control")
+           bp::args("self", "data", "df_dx", "df_du"),
+           "Update the force derivatives.\n\n"
+           ":param data: cost data\n"
+           ":param df_dx: Jacobian of the force with respect to the state\n"
+           ":param df_du: Jacobian of the force with respect to the control")
       .def("createData", &ContactModel6DLoop::createData,
            bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
@@ -85,7 +89,8 @@ void exposeContact6DLoop() {
           "joint1_placement",
           bp::make_function(&ContactModel6DLoop::get_joint1_placement,
                             bp::return_value_policy<bp::return_by_value>()),
-          "Placement of the first contact frame with respect to the parent joint")
+          "Placement of the first contact frame with respect to the parent "
+          "joint")
       .add_property(
           "joint2_id",
           bp::make_function(&ContactModel6DLoop::get_joint2_id,
@@ -95,7 +100,8 @@ void exposeContact6DLoop() {
           "joint2_placement",
           bp::make_function(&ContactModel6DLoop::get_joint2_placement,
                             bp::return_value_policy<bp::return_by_value>()),
-          "Placement of the second contact frame with respect to the parent joint")
+          "Placement of the second contact frame with respect to the parent "
+          "joint")
       .add_property(
           "gains",
           bp::make_function(&ContactModel6DLoop::get_gains,

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -98,8 +98,6 @@ void exposeContact6DLoop() {
           "contact gains")
       .def(CopyableVisitor<ContactModel6DLoop>());
 
-#pragma GCC diagnostic pop
-
   bp::register_ptr_to_python<boost::shared_ptr<ContactData6DLoop> >();
 
   bp::class_<ContactData6DLoop, bp::bases<ContactDataAbstract> >(

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -1,0 +1,233 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+//                          Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "crocoddyl/multibody/contacts/contact-6d-loop.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
+#include "python/crocoddyl/utils/copyable.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void exposeContact6DLoop() {
+  bp::register_ptr_to_python<boost::shared_ptr<ContactModel6DLoop> >();
+
+  bp::class_<ContactModel6DLoop, bp::bases<ContactModelAbstract> >(
+      "ContactModel6DLoop",
+      "Rigid 6D contact model.\n\n"
+      "It defines a rigid 6D contact models based on acceleration-based "
+      "holonomic constraints.\n"
+      "The calc and calcDiff functions compute the contact Jacobian and drift "
+      "(holonomic constraint) or\n"
+      "the derivatives of the holonomic constraint, respectively.",
+      bp::init<boost::shared_ptr<StateMultibody>, int, pinocchio::SE3, int,
+               pinocchio::SE3, pinocchio::ReferenceFrame, std::size_t,
+               bp::optional<Eigen::Vector2d> >(
+          bp::args("self", "state", "joint1_id", "joint1_placement",
+                   "joint2_id", "joint2_placement", "ref", "nu", "gains"),
+          "Initialize the contact model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param joint1_id: reference joint id of the first contact frame\n"
+          ":param joint1_placement: Placement of the first contact frame\n"
+          ":param joint2_id: reference joint id of the second contact frames\n"
+          ":param joint2_placement: Placement of the second contact frame\n"
+          ":param ref: reference frames of contact\n"
+          ":param nu: dimension of control vector\n"
+          ":param gains: gains of the contact model (default "
+          "np.matrix([0.,0.]))"))
+      .def("calc", &ContactModel6DLoop::calc, bp::args("self", "data", "x"),
+           "Compute the 6D contact Jacobian and drift.\n\n"
+           "The rigid contact model throught acceleration-base holonomic "
+           "constraint\n"
+           "of the contact frame placement.\n"
+           ":param data: contact data\n"
+           ":param x: state point (dim. state.nx)")
+      .def("calcDiff", &ContactModel6DLoop::calcDiff,
+           bp::args("self", "data", "x"),
+           "Compute the derivatives of the 6D contact holonomic constraint.\n\n"
+           "The rigid contact model throught acceleration-base holonomic "
+           "constraint\n"
+           "of the contact frame placement.\n"
+           "It assumes that calc has been run first.\n"
+           ":param data: cost data\n"
+           ":param x: state point (dim. state.nx)")
+      .def("updateForce", &ContactModel6DLoop::updateForce,
+           bp::args("self", "data", "force"),
+           "Convert the Lagrangian into a stack of spatial forces.\n\n"
+           ":param data: cost data\n"
+           ":param force: force vector (dimension 6)")
+      .def("createData", &ContactModel6DLoop::createData,
+           bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the 6D contact data.\n\n"
+           "Each contact model has its own data that needs to be allocated. "
+           "This function\n"
+           "returns the allocated data for a predefined cost.\n"
+           ":param data: Pinocchio data\n"
+           ":return contact data.")
+      .add_property(
+          "joint1_id",
+          bp::make_function(&ContactModel6DLoop::get_joint1_id,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "reference joint id of the first contact frame")
+      .add_property(
+          "joint1_placement",
+          bp::make_function(&ContactModel6DLoop::get_joint1_placement,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "Placement of the first contact frame")
+      .add_property(
+          "joint2_id",
+          bp::make_function(&ContactModel6DLoop::get_joint2_id,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "reference joint id of the second contact frame")
+      .add_property(
+          "joint2_placement",
+          bp::make_function(&ContactModel6DLoop::get_joint2_placement,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "Placement of the second contact frame")
+      .add_property(
+          "gains",
+          bp::make_function(&ContactModel6DLoop::get_gains,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "contact gains")
+      .def(CopyableVisitor<ContactModel6DLoop>());
+
+#pragma GCC diagnostic pop
+
+  bp::register_ptr_to_python<boost::shared_ptr<ContactData6DLoop> >();
+
+  bp::class_<ContactData6DLoop, bp::bases<ContactDataAbstract> >(
+      "ContactData6DLoop", "Data for 6DLoop contact.\n\n",
+      bp::init<ContactModel6DLoop*, pinocchio::Data*>(
+          bp::args("self", "model", "data"),
+          "Create 6DLoop contact data.\n\n"
+          ":param model: 6DLoop contact model\n"
+          ":param data: Pinocchio data")[bp::with_custodian_and_ward<
+          1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property(
+          "v1_partial_dq",
+          bp::make_getter(&ContactData6DLoop::v1_partial_dq,
+                          bp::return_internal_reference<>()),
+          "Jacobian of the spatial velocity of the first contact frame wrt q")
+      .add_property("a1_partial_dq",
+                    bp::make_getter(&ContactData6DLoop::a1_partial_dq,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the first contact "
+                    "frame wrt q")
+      .add_property("a1_partial_dv",
+                    bp::make_getter(&ContactData6DLoop::a1_partial_dv,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the first contact "
+                    "frame wrt v")
+      .add_property("a1_partial_da",
+                    bp::make_getter(&ContactData6DLoop::a1_partial_da,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the first contact "
+                    "frame wrt a")
+      .add_property(
+          "v2_partial_dq",
+          bp::make_getter(&ContactData6DLoop::v2_partial_dq,
+                          bp::return_internal_reference<>()),
+          "Jacobian of the spatial velocity of the second contact frame wrt q")
+      .add_property("a2_partial_dq",
+                    bp::make_getter(&ContactData6DLoop::a2_partial_dq,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the second "
+                    "contact frame wrt q")
+      .add_property("a2_partial_dv",
+                    bp::make_getter(&ContactData6DLoop::a2_partial_dv,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the second "
+                    "contact frame wrt v")
+      .add_property("a2_partial_da",
+                    bp::make_getter(&ContactData6DLoop::a2_partial_da,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the spatial acceleration of the second "
+                    "contact frame wrt a")
+      .add_property("da0_dx",
+                    bp::make_getter(&ContactData6DLoop::da0_dx,
+                                    bp::return_internal_reference<>()),
+                    "Derivative of the acceleration drift wrt x")
+      .add_property("da0_dq_t1",
+                    bp::make_getter(&ContactData6DLoop::da0_dq_t1,
+                                    bp::return_internal_reference<>()),
+                    "Derivative of the acceleration drift wrt q - part 1")
+      .add_property("da0_dq_t2",
+                    bp::make_getter(&ContactData6DLoop::da0_dq_t2,
+                                    bp::return_internal_reference<>()),
+                    "Derivative of the acceleration drift wrt q - part 2")
+      .add_property("da0_dq_t3",
+                    bp::make_getter(&ContactData6DLoop::da0_dq_t3,
+                                    bp::return_internal_reference<>()),
+                    "Derivative of the acceleration drift wrt q - part 3")
+      .add_property("j1Xf1",
+                    bp::make_getter(&ContactData6DLoop::j1Xf1,
+                                    bp::return_internal_reference<>()),
+                    "Placement of the first contact frame in the joint frame - "
+                    "Action Matrix")
+      .add_property("j2Xf2",
+                    bp::make_getter(&ContactData6DLoop::j2Xf2,
+                                    bp::return_internal_reference<>()),
+                    "Placement of the second contact frame in the joint frame "
+                    "- Action Matrix")
+      .add_property("f1Mf2",
+                    bp::make_getter(&ContactData6DLoop::f1Mf2,
+                                    bp::return_internal_reference<>()),
+                    "Relative placement of the contact frames")
+      .add_property("f1Xf2",
+                    bp::make_getter(&ContactData6DLoop::f1Xf2,
+                                    bp::return_internal_reference<>()),
+                    "Relative placement of the contact frames - Action Matrix")
+      .add_property("f1Jf1",
+                    bp::make_getter(&ContactData6DLoop::f1Jf1,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the first contact frame")
+      .add_property("f2Jf2",
+                    bp::make_getter(&ContactData6DLoop::f2Jf2,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the second frame in the joint frame")
+      .add_property("j1Jj1",
+                    bp::make_getter(&ContactData6DLoop::j1Jj1,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the first joint in the joint frame")
+      .add_property("j2Jj2",
+                    bp::make_getter(&ContactData6DLoop::j2Jj2,
+                                    bp::return_internal_reference<>()),
+                    "Jacobian of the second contact frame")
+      .add_property("f1vf1",
+                    bp::make_getter(&ContactData6DLoop::f1vf1,
+                                    bp::return_internal_reference<>()),
+                    "Velocity of the first contact frame")
+      .add_property("f2vf2",
+                    bp::make_getter(&ContactData6DLoop::f2vf2,
+                                    bp::return_internal_reference<>()),
+                    "Velocity of the second contact frame")
+      .add_property(
+          "f1vf2",
+          bp::make_getter(&ContactData6DLoop::f1vf2,
+                          bp::return_internal_reference<>()),
+          "Velocity of the second contact frame in the first contact frame")
+      .add_property("f1af1",
+                    bp::make_getter(&ContactData6DLoop::f1af1,
+                                    bp::return_internal_reference<>()),
+                    "Acceleration of the first contact frame")
+      .add_property("f2af2",
+                    bp::make_getter(&ContactData6DLoop::f2af2,
+                                    bp::return_internal_reference<>()),
+                    "Acceleration of the second contact frame")
+      .add_property(
+          "f1af2",
+          bp::make_getter(&ContactData6DLoop::f1af2,
+                          bp::return_internal_reference<>()),
+          "Acceleration of the second contact frame in the first contact frame")
+      .def(CopyableVisitor<ContactData6DLoop>());
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -30,7 +30,7 @@ void exposeContact6DLoop() {
                pinocchio::SE3, pinocchio::ReferenceFrame, std::size_t,
                bp::optional<Eigen::Vector2d> >(
           bp::args("self", "state", "joint1_id", "joint1_placement",
-                   "joint2_id", "joint2_placement", "ref", "nu", "gains"),
+                   "joint2_id", "joint2_placement", "type", "nu", "gains"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param joint1_id: Parent joint id of the first contact frame\n"
@@ -39,7 +39,7 @@ void exposeContact6DLoop() {
           ":param joint2_id: Parent joint id of the second contact frames\n"
           ":param joint2_placement: Placement of the second contact frame with "
           "respect to the parent joint\n"
-          ":param ref: reference frame of contact (must be pinocchio::LOCAL)\n"
+          ":param type: reference frame of contact (must be pinocchio::LOCAL)\n"
           ":param nu: dimension of control vector\n"
           ":param gains: gains of the contact model (default "
           "np.matrix([0.,0.]))"))

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -33,16 +33,15 @@ void exposeContact6DLoop() {
                    "joint2_id", "joint2_placement", "ref", "nu", "gains"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
-          ":param joint1_id: reference joint id of the first contact frame\n"
-          ":param joint1_placement: Placement of the first contact frame\n"
-          ":param joint2_id: reference joint id of the second contact frames\n"
-          ":param joint2_placement: Placement of the second contact frame\n"
-          ":param ref: reference frames of contact\n"
+          ":param joint1_id: Parent joint id of the first contact frame\n"
+          ":param joint1_placement: Placement of the first contact frame with respect to the parent joint\n"
+          ":param joint2_id: Parent joint id of the second contact frames\n"
+          ":param joint2_placement: Placement of the second contact frame with respect to the parent joint\n"
+          ":param ref: reference frame of contact (must be pinocchio::LOCAL)\n"
           ":param nu: dimension of control vector\n"
-          ":param gains: gains of the contact model (default "
-          "np.matrix([0.,0.]))"))
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
       .def("calc", &ContactModel6DLoop::calc, bp::args("self", "data", "x"),
-           "Compute the 6D contact Jacobian and drift.\n\n"
+           "Compute the 6D loop-contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic "
            "constraint\n"
            "of the contact frame placement.\n"
@@ -50,7 +49,7 @@ void exposeContact6DLoop() {
            ":param x: state point (dim. state.nx)")
       .def("calcDiff", &ContactModel6DLoop::calcDiff,
            bp::args("self", "data", "x"),
-           "Compute the derivatives of the 6D contact holonomic constraint.\n\n"
+           "Compute the derivatives of the 6D loop-contact holonomic constraint.\n\n"
            "The rigid contact model throught acceleration-base holonomic "
            "constraint\n"
            "of the contact frame placement.\n"
@@ -65,7 +64,7 @@ void exposeContact6DLoop() {
       .def("createData", &ContactModel6DLoop::createData,
            bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
-           "Create the 6D contact data.\n\n"
+           "Create the 6D loop-contact data.\n\n"
            "Each contact model has its own data that needs to be allocated. "
            "This function\n"
            "returns the allocated data for a predefined cost.\n"
@@ -75,27 +74,27 @@ void exposeContact6DLoop() {
           "joint1_id",
           bp::make_function(&ContactModel6DLoop::get_joint1_id,
                             bp::return_value_policy<bp::return_by_value>()),
-          "reference joint id of the first contact frame")
+          "Parent joint id of the first contact frame")
       .add_property(
           "joint1_placement",
           bp::make_function(&ContactModel6DLoop::get_joint1_placement,
                             bp::return_value_policy<bp::return_by_value>()),
-          "Placement of the first contact frame")
+          "Placement of the first contact frame with respect to the parent joint")
       .add_property(
           "joint2_id",
           bp::make_function(&ContactModel6DLoop::get_joint2_id,
                             bp::return_value_policy<bp::return_by_value>()),
-          "reference joint id of the second contact frame")
+          "Parent joint id of the second contact frame")
       .add_property(
           "joint2_placement",
           bp::make_function(&ContactModel6DLoop::get_joint2_placement,
                             bp::return_value_policy<bp::return_by_value>()),
-          "Placement of the second contact frame")
+          "Placement of the second contact frame with respect to the parent joint")
       .add_property(
           "gains",
           bp::make_function(&ContactModel6DLoop::get_gains,
                             bp::return_value_policy<bp::return_by_value>()),
-          "contact gains")
+          "Baumegarte stabilisation gains (Kp, Kd)")
       .def(CopyableVisitor<ContactModel6DLoop>());
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactData6DLoop> >();
@@ -104,8 +103,8 @@ void exposeContact6DLoop() {
       "ContactData6DLoop", "Data for 6DLoop contact.\n\n",
       bp::init<ContactModel6DLoop*, pinocchio::Data*>(
           bp::args("self", "model", "data"),
-          "Create 6DLoop contact data.\n\n"
-          ":param model: 6DLoop contact model\n"
+          "Create 6D loop-contact data.\n\n"
+          ":param model: 6D loop-contact model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<
           1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property(
@@ -151,19 +150,19 @@ void exposeContact6DLoop() {
       .add_property("da0_dx",
                     bp::make_getter(&ContactData6DLoop::da0_dx,
                                     bp::return_internal_reference<>()),
-                    "Derivative of the acceleration drift wrt x")
+                    "Jacobian of the acceleration drift wrt x")
       .add_property("da0_dq_t1",
                     bp::make_getter(&ContactData6DLoop::da0_dq_t1,
                                     bp::return_internal_reference<>()),
-                    "Derivative of the acceleration drift wrt q - part 1")
+                    "Jacobian of the acceleration drift wrt q - part 1")
       .add_property("da0_dq_t2",
                     bp::make_getter(&ContactData6DLoop::da0_dq_t2,
                                     bp::return_internal_reference<>()),
-                    "Derivative of the acceleration drift wrt q - part 2")
+                    "Jacobian of the acceleration drift wrt q - part 2")
       .add_property("da0_dq_t3",
                     bp::make_getter(&ContactData6DLoop::da0_dq_t3,
                                     bp::return_internal_reference<>()),
-                    "Derivative of the acceleration drift wrt q - part 3")
+                    "Jacobian of the acceleration drift wrt q - part 3")
       .add_property("j1Xf1",
                     bp::make_getter(&ContactData6DLoop::j1Xf1,
                                     bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -168,12 +168,14 @@ void exposeContact6DLoop() {
       .add_property("f1Xj1",
                     bp::make_getter(&ContactData6DLoop::f1Xj1,
                                     bp::return_internal_reference<>()),
-                    "Inverse of the placement of the first contact frame in the joint frame - "
+                    "Inverse of the placement of the first contact frame in "
+                    "the joint frame - "
                     "Action Matrix")
       .add_property("f2Xj2",
                     bp::make_getter(&ContactData6DLoop::f2Xj2,
                                     bp::return_internal_reference<>()),
-                    "Inverse of the placement of the second contact frame in the joint frame "
+                    "Inverse of the placement of the second contact frame in "
+                    "the joint frame "
                     "- Action Matrix")
       .add_property("f1Mf2",
                     bp::make_getter(&ContactData6DLoop::f1Mf2,

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -165,15 +165,15 @@ void exposeContact6DLoop() {
                     bp::make_getter(&ContactData6DLoop::da0_dq_t3,
                                     bp::return_internal_reference<>()),
                     "Jacobian of the acceleration drift wrt q - part 3")
-      .add_property("j1Xf1",
-                    bp::make_getter(&ContactData6DLoop::j1Xf1,
+      .add_property("f1Xj1",
+                    bp::make_getter(&ContactData6DLoop::f1Xj1,
                                     bp::return_internal_reference<>()),
-                    "Placement of the first contact frame in the joint frame - "
+                    "Inverse of the placement of the first contact frame in the joint frame - "
                     "Action Matrix")
-      .add_property("j2Xf2",
-                    bp::make_getter(&ContactData6DLoop::j2Xf2,
+      .add_property("f2Xj2",
+                    bp::make_getter(&ContactData6DLoop::f2Xj2,
                                     bp::return_internal_reference<>()),
-                    "Placement of the second contact frame in the joint frame "
+                    "Inverse of the placement of the second contact frame in the joint frame "
                     "- Action Matrix")
       .add_property("f1Mf2",
                     bp::make_getter(&ContactData6DLoop::f1Mf2,

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d-loop.cpp
@@ -61,6 +61,12 @@ void exposeContact6DLoop() {
            "Convert the Lagrangian into a stack of spatial forces.\n\n"
            ":param data: cost data\n"
            ":param force: force vector (dimension 6)")
+      .def("updateForceDiff", &ContactModel6DLoop::updateForceDiff,
+              bp::args("self", "data", "df_dx", "df_du"),
+              "Update the force derivatives.\n\n"
+              ":param data: cost data\n"
+              ":param df_dx: Jacobian of the force with respect to the state\n"
+              ":param df_du: Jacobian of the force with respect to the control")
       .def("createData", &ContactModel6DLoop::createData,
            bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),

--- a/bindings/python/crocoddyl/multibody/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/multibody.cpp
@@ -56,6 +56,7 @@ void exposeMultibody() {
   exposeContact2D();
   exposeContact3D();
   exposeContact6D();
+  exposeContact6DLoop();
   exposeImpulse3D();
   exposeImpulse6D();
 }

--- a/bindings/python/crocoddyl/multibody/multibody.hpp
+++ b/bindings/python/crocoddyl/multibody/multibody.hpp
@@ -61,6 +61,7 @@ void exposeContact1D();
 void exposeContact2D();
 void exposeContact3D();
 void exposeContact6D();
+void exposeContact6DLoop();
 void exposeImpulse3D();
 void exposeImpulse6D();
 void exposeMultibody();

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hpp
@@ -679,10 +679,13 @@ struct DifferentialActionDataContactInvDynamicsTpl
       for (it = d->contacts->contacts.begin(),
           end = d->contacts->contacts.end();
            it != end; ++it) {
-        if (id == it->second->frame) {  // TODO(cmastalli): use model->get_id()
-                                        // and avoid to pass id in constructor
-          contact = it->second.get();
-          break;
+        if (it->second->nf == 1) {
+          if (id == // TODO(foster): not sure this checking if nf == 1 logic is correct
+              it->second->force_datas[0].frame) {  // TODO(cmastalli): use model->get_id()
+                                    // and avoid to pass id in constructor
+            contact = it->second.get();
+            break;
+          }
         }
       }
     }

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hxx
@@ -106,7 +106,8 @@ void DifferentialActionModelContactInvDynamicsTpl<Scalar>::init(
          ++it_m) {
       const boost::shared_ptr<ContactItem>& contact = it_m->second;
       const std::string name = contact->name;
-      const pinocchio::FrameIndex id = contact->contact->get_id();
+      // TODO(jfoster): should this be generalised to account for loops? How would that work? Just indexing the first force for now
+      const pinocchio::FrameIndex id = contact->contact->get_id(0);
       const std::size_t nc_i = contact->contact->get_nc();
       const bool active = contact->active;
       constraints_->addConstraint(

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -94,7 +94,7 @@ class ContactModelAbstractTpl {
    * @param[in] data   Contact data
    * @param[in] force  Contact force
    */
-  void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data,
+  virtual void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data,
                        const MatrixXs& df_dx, const MatrixXs& df_du) const;
 
   /**

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -94,8 +94,9 @@ class ContactModelAbstractTpl {
    * @param[in] data   Contact data
    * @param[in] force  Contact force
    */
-  virtual void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data,
-                       const MatrixXs& df_dx, const MatrixXs& df_du) const;
+  virtual void updateForceDiff(
+      const boost::shared_ptr<ContactDataAbstract>& data, const MatrixXs& df_dx,
+      const MatrixXs& df_du) const;
 
   /**
    * @brief Set the stack of spatial forces to zero

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -140,12 +140,12 @@ class ContactModelAbstractTpl {
   /**
    * @brief Return the reference frame id
    */
-  pinocchio::FrameIndex get_id() const;
+  pinocchio::FrameIndex get_id(const int force_index) const;
 
   /**
    * @brief Modify the reference frame id
    */
-  void set_id(const pinocchio::FrameIndex id);
+  void set_id(const int force_index, const pinocchio::FrameIndex id);
 
   /**
    * @brief Modify the type of contact
@@ -178,7 +178,9 @@ class ContactModelAbstractTpl {
   std::size_t nf_;
   std::vector<pinocchio::FrameIndex>
       id_;  //!< Reference frame id of the contact
-  std::vector<pinocchio::ReferenceFrame> type_;  //!< Type of contact
+  std::vector<pinocchio::SE3> placements_;  //!< Placement of contact relative to parent
+  // TODO(jfoster): only allowing one type per contact model
+  pinocchio::ReferenceFrame type_;  //!< Type of contact
 };
 
 template <typename _Scalar>
@@ -196,7 +198,7 @@ struct ContactDataAbstractTpl : public InteractionDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactDataAbstractTpl(Model<Scalar>* const model,
                          pinocchio::DataTpl<Scalar>* const data, const int nf)
-      : InteractionDataAbstractTpl<Scalar>(model, data, nf),
+      : InteractionDataAbstractTpl<Scalar>(model, nf),
         pinocchio(data),
         a0(model->get_nc()),
         da0_dx(model->get_nc(), model->get_state()->get_ndx()),

--- a/include/crocoddyl/multibody/contact-base.hxx
+++ b/include/crocoddyl/multibody/contact-base.hxx
@@ -15,17 +15,28 @@ namespace crocoddyl {
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
     boost::shared_ptr<StateMultibody> state,
-    const pinocchio::ReferenceFrame type,
-    const std::size_t nf,
-    const std::size_t nc,
-    const std::size_t nu)
-    : state_(state), nc_(nc), nu_(nu), nf_(nf), id_(nf, 0), type_(nf, type) {}
+    const pinocchio::ReferenceFrame type, const std::size_t nf,
+    const std::size_t nc, const std::size_t nu)
+    : state_(state),
+      nc_(nc),
+      nu_(nu),
+      nf_(nf),
+      id_(nf, 0),
+      placements_(nf, pinocchio::SE3::Identity()),
+      type_(type) {}
 
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
     boost::shared_ptr<StateMultibody> state,
-    const pinocchio::ReferenceFrame type, const std::size_t nf, const std::size_t nc)
-    : state_(state), nc_(nc), nu_(state->get_nv()), nf_(nf), id_(nf,0), type_(nf, type) {}
+    const pinocchio::ReferenceFrame type, const std::size_t nf,
+    const std::size_t nc)
+    : state_(state),
+      nc_(nc),
+      nu_(state->get_nv()),
+      nf_(nf),
+      id_(nf, 0),
+      placements_(nf, pinocchio::SE3::Identity()),
+      type_(type) {}
 
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
@@ -76,8 +87,7 @@ void ContactModelAbstractTpl<Scalar>::updateForceDiff(
 template <typename Scalar>
 void ContactModelAbstractTpl<Scalar>::setZeroForce(
     const boost::shared_ptr<ContactDataAbstract>& data) const {
-  for (int i = 0; i < nf_; ++i)
-  {
+  for (size_t i = 0; i < nf_; ++i) {
     data->force_datas[i].f.setZero();
     data->force_datas[i].fext.setZero();
   }
@@ -125,24 +135,26 @@ std::size_t ContactModelAbstractTpl<Scalar>::get_nu() const {
 }
 
 template <typename Scalar>
-pinocchio::FrameIndex ContactModelAbstractTpl<Scalar>::get_id() const {
-  return id_[0]; // TODO(jfoster): index properly
+pinocchio::FrameIndex ContactModelAbstractTpl<Scalar>::get_id(
+    const int force_index) const {
+  return id_[force_index];
 }
 
 template <typename Scalar>
 pinocchio::ReferenceFrame ContactModelAbstractTpl<Scalar>::get_type() const {
-  return type_[0]; // TODO(jfoster): index properly
+  return type_;
 }
 
 template <typename Scalar>
-void ContactModelAbstractTpl<Scalar>::set_id(const pinocchio::FrameIndex id) {
-  id_[0] = id; // TODO(jfoster): index properly
+void ContactModelAbstractTpl<Scalar>::set_id(const int force_index,
+                                             const pinocchio::FrameIndex id) {
+  id_[force_index] = id;
 }
 
 template <typename Scalar>
 void ContactModelAbstractTpl<Scalar>::set_type(
     const pinocchio::ReferenceFrame type) {
-  type_[0] = type; // TODO(jfoster): index properly
+  type_ = type;
 }
 
 template <class Scalar>

--- a/include/crocoddyl/multibody/contact-base.hxx
+++ b/include/crocoddyl/multibody/contact-base.hxx
@@ -15,15 +15,17 @@ namespace crocoddyl {
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
     boost::shared_ptr<StateMultibody> state,
-    const pinocchio::ReferenceFrame type, const std::size_t nc,
+    const pinocchio::ReferenceFrame type,
+    const std::size_t nf,
+    const std::size_t nc,
     const std::size_t nu)
-    : state_(state), nc_(nc), nu_(nu), id_(0), type_(type) {}
+    : state_(state), nc_(nc), nu_(nu), nf_(nf), id_(nf, 0), type_(nf, type) {}
 
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
     boost::shared_ptr<StateMultibody> state,
-    const pinocchio::ReferenceFrame type, const std::size_t nc)
-    : state_(state), nc_(nc), nu_(state->get_nv()), id_(0), type_(type) {}
+    const pinocchio::ReferenceFrame type, const std::size_t nf, const std::size_t nc)
+    : state_(state), nc_(nc), nu_(state->get_nv()), nf_(nf), id_(nf,0), type_(nf, type) {}
 
 template <typename Scalar>
 ContactModelAbstractTpl<Scalar>::ContactModelAbstractTpl(
@@ -74,8 +76,11 @@ void ContactModelAbstractTpl<Scalar>::updateForceDiff(
 template <typename Scalar>
 void ContactModelAbstractTpl<Scalar>::setZeroForce(
     const boost::shared_ptr<ContactDataAbstract>& data) const {
-  data->f.setZero();
-  data->fext.setZero();
+  for (int i = 0; i < nf_; ++i)
+  {
+    data->force_datas[i].f.setZero();
+    data->force_datas[i].fext.setZero();
+  }
 }
 
 template <typename Scalar>
@@ -90,7 +95,7 @@ boost::shared_ptr<ContactDataAbstractTpl<Scalar> >
 ContactModelAbstractTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar>* const data) {
   return boost::allocate_shared<ContactDataAbstract>(
-      Eigen::aligned_allocator<ContactDataAbstract>(), this, data);
+      Eigen::aligned_allocator<ContactDataAbstract>(), this, data, nf_);
 }
 
 template <typename Scalar>
@@ -105,6 +110,11 @@ ContactModelAbstractTpl<Scalar>::get_state() const {
 }
 
 template <typename Scalar>
+std::size_t ContactModelAbstractTpl<Scalar>::get_nf() const {
+  return nf_;
+}
+
+template <typename Scalar>
 std::size_t ContactModelAbstractTpl<Scalar>::get_nc() const {
   return nc_;
 }
@@ -116,23 +126,23 @@ std::size_t ContactModelAbstractTpl<Scalar>::get_nu() const {
 
 template <typename Scalar>
 pinocchio::FrameIndex ContactModelAbstractTpl<Scalar>::get_id() const {
-  return id_;
+  return id_[0]; // TODO(jfoster): index properly
 }
 
 template <typename Scalar>
 pinocchio::ReferenceFrame ContactModelAbstractTpl<Scalar>::get_type() const {
-  return type_;
+  return type_[0]; // TODO(jfoster): index properly
 }
 
 template <typename Scalar>
 void ContactModelAbstractTpl<Scalar>::set_id(const pinocchio::FrameIndex id) {
-  id_ = id;
+  id_[0] = id; // TODO(jfoster): index properly
 }
 
 template <typename Scalar>
 void ContactModelAbstractTpl<Scalar>::set_type(
     const pinocchio::ReferenceFrame type) {
-  type_ = type;
+  type_[0] = type; // TODO(jfoster): index properly
 }
 
 template <class Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -192,7 +192,7 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactData1DTpl(Model<Scalar>* const model,
                    pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Base(model, data, 1),
         v(Motion::Zero()),
         f_local(Force::Zero()),
         da0_local_dx(3, model->get_state()->get_ndx()),
@@ -205,9 +205,12 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     a0_local.setZero();
     dp.setZero();
     dp_local.setZero();
@@ -226,20 +229,14 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
     fXjdv_dq.setZero();
     fXjda_dq.setZero();
     fXjda_dv.setZero();
-    oRf.setZero();
     fJf_df.setZero();
   }
 
   using Base::a0;
   using Base::da0_dx;
-  using Base::df_du;
-  using Base::df_dx;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
   using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   Motion v;
   Vector3s a0_local;
@@ -261,7 +258,6 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs fXjdv_dq;
   Matrix6xs fXjda_dq;
   Matrix6xs fXjda_dv;
-  Matrix2s oRf;
   Matrix3xs fJf_df;
 };
 

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -196,18 +196,13 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
         v(Motion::Zero()),
         f_local(Force::Zero()),
         da0_local_dx(3, model->get_state()->get_ndx()),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dv(6, model->get_state()->get_nv()),
-        a_partial_da(6, model->get_state()->get_nv()),
         fXjdv_dq(6, model->get_state()->get_nv()),
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
-    fdata.frame = model->get_id();
+    fdata.frame = model->get_id(0);
     fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
     fdata.fXj = fdata.jMf.inverse().toActionMatrix();
 
@@ -215,11 +210,6 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
     dp.setZero();
     dp_local.setZero();
     da0_local_dx.setZero();
-    fJf.setZero();
-    v_partial_dq.setZero();
-    a_partial_dq.setZero();
-    a_partial_dv.setZero();
-    a_partial_da.setZero();
     vv_skew.setZero();
     vw_skew.setZero();
     a0_skew.setZero();
@@ -244,11 +234,6 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
   Vector3s dp_local;
   Force f_local;
   Matrix3xs da0_local_dx;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs a_partial_dq;
-  Matrix6xs a_partial_dv;
-  Matrix6xs a_partial_da;
   Matrix3s vv_skew;
   Matrix3s vw_skew;
   Matrix3s a0_skew;

--- a/include/crocoddyl/multibody/contacts/contact-2d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-2d.hpp
@@ -148,7 +148,7 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactData2DTpl(Model<Scalar>* const model,
                    pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Base(model, data, 1),
         fJf(6, model->get_state()->get_nv()),
         v_partial_dq(6, model->get_state()->get_nv()),
         a_partial_dq(6, model->get_state()->get_nv()),
@@ -157,9 +157,12 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
         fXjdv_dq(6, model->get_state()->get_nv()),
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     fJf.setZero();
     v_partial_dq.setZero();
     a_partial_dq.setZero();
@@ -179,12 +182,8 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
   using Base::da0_dx;
   using Base::df_du;
   using Base::df_dx;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
-  using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   pinocchio::MotionTpl<Scalar> v;
   pinocchio::MotionTpl<Scalar> a;

--- a/include/crocoddyl/multibody/contacts/contact-2d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-2d.hpp
@@ -149,25 +149,15 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
   ContactData2DTpl(Model<Scalar>* const model,
                    pinocchio::DataTpl<Scalar>* const data)
       : Base(model, data, 1),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dv(6, model->get_state()->get_nv()),
-        a_partial_da(6, model->get_state()->get_nv()),
         fXjdv_dq(6, model->get_state()->get_nv()),
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
-    fdata.frame = model->get_id();
+    fdata.frame = model->get_id(0);
     fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
     fdata.fXj = fdata.jMf.inverse().toActionMatrix();
 
-    fJf.setZero();
-    v_partial_dq.setZero();
-    a_partial_dq.setZero();
-    a_partial_dv.setZero();
-    a_partial_da.setZero();
     fXjdv_dq.setZero();
     fXjda_dq.setZero();
     fXjda_dv.setZero();
@@ -187,11 +177,6 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
 
   pinocchio::MotionTpl<Scalar> v;
   pinocchio::MotionTpl<Scalar> a;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs a_partial_dq;
-  Matrix6xs a_partial_dv;
-  Matrix6xs a_partial_da;
   Matrix6xs fXjdv_dq;
   Matrix6xs fXjda_dq;
   Matrix6xs fXjda_dv;

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -179,7 +179,7 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactData3DTpl(Model<Scalar>* const model,
                    pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Base(model, data, 1),
         v(Motion::Zero()),
         f_local(Force::Zero()),
         da0_local_dx(3, model->get_state()->get_ndx()),
@@ -192,9 +192,12 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     a0_local.setZero();
     dp.setZero();
     dp_local.setZero();
@@ -218,14 +221,9 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
 
   using Base::a0;
   using Base::da0_dx;
-  using Base::df_du;
-  using Base::df_dx;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
   using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   Motion v;
   Vector3s a0_local;

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -183,18 +183,13 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
         v(Motion::Zero()),
         f_local(Force::Zero()),
         da0_local_dx(3, model->get_state()->get_ndx()),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dv(6, model->get_state()->get_nv()),
-        a_partial_da(6, model->get_state()->get_nv()),
         fXjdv_dq(6, model->get_state()->get_nv()),
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
-    fdata.frame = model->get_id();
+    fdata.frame = model->get_id(0);
     fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
     fdata.fXj = fdata.jMf.inverse().toActionMatrix();
 
@@ -202,11 +197,6 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
     dp.setZero();
     dp_local.setZero();
     da0_local_dx.setZero();
-    fJf.setZero();
-    v_partial_dq.setZero();
-    a_partial_dq.setZero();
-    a_partial_dv.setZero();
-    a_partial_da.setZero();
     vv_skew.setZero();
     vw_skew.setZero();
     a0_skew.setZero();
@@ -231,11 +221,6 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
   Vector3s dp_local;
   Force f_local;
   Matrix3xs da0_local_dx;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs a_partial_dq;
-  Matrix6xs a_partial_dv;
-  Matrix6xs a_partial_da;
   Matrix3s vv_skew;
   Matrix3s vw_skew;
   Matrix3s a0_skew;

--- a/include/crocoddyl/multibody/contacts/contact-3d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hxx
@@ -16,7 +16,7 @@ ContactModel3DTpl<Scalar>::ContactModel3DTpl(
     const std::size_t nu, const Vector2s& gains)
     : Base(state, type, 1, 3, nu), xref_(xref), gains_(gains) {
   id_[0] = id;
-  type_[0] = type;
+  type_ = type;
 }
 
 template <typename Scalar>
@@ -26,7 +26,7 @@ ContactModel3DTpl<Scalar>::ContactModel3DTpl(
     const Vector2s& gains)
     : Base(state, type, 1, 3), xref_(xref), gains_(gains) {
   id_[0] = id;
-  type_[0] = type;
+  type_ = type;
 }
 
 #pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has
@@ -73,7 +73,7 @@ void ContactModel3DTpl<Scalar>::calc(
   pinocchio::updateFramePlacement(*state_->get_pinocchio().get(),
                                   *d->pinocchio, id_[0]);
   pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
-                              id_[0], pinocchio::LOCAL, d->fJf);
+                              id_[0], pinocchio::LOCAL, fdata.fJf);
   d->v = pinocchio::getFrameVelocity(*state_->get_pinocchio().get(),
                                      *d->pinocchio, id_[0]);
   d->a0_local = pinocchio::getFrameClassicalAcceleration(
@@ -91,14 +91,14 @@ void ContactModel3DTpl<Scalar>::calc(
   if (gains_[1] != 0.) {
     d->a0_local += gains_[1] * d->v.linear();
   }
-  switch (type_[0]) {
+  switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
-      d->Jc = d->fJf.template topRows<3>();
+      d->Jc = fdata.fJf.template topRows<3>();
       d->a0 = d->a0_local;
       break;
     case pinocchio::ReferenceFrame::WORLD:
     case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
-      d->Jc.noalias() = oRf * d->fJf.template topRows<3>();
+      d->Jc.noalias() = oRf * fdata.fJf.template topRows<3>();
       d->a0.noalias() = oRf * d->a0_local;
       break;
   }
@@ -119,13 +119,13 @@ void ContactModel3DTpl<Scalar>::calcDiff(
 #endif
   pinocchio::getJointAccelerationDerivatives(
       *state_->get_pinocchio().get(), *d->pinocchio, joint, pinocchio::LOCAL,
-      d->v_partial_dq, d->a_partial_dq, d->a_partial_dv, d->a_partial_da);
+      fdata.v_partial_dq, fdata.a_partial_dq, fdata.a_partial_dv, fdata.a_partial_da);
   const std::size_t nv = state_->get_nv();
   pinocchio::skew(d->v.linear(), d->vv_skew);
   pinocchio::skew(d->v.angular(), d->vw_skew);
-  d->fXjdv_dq.noalias() = fdata.fXj * d->v_partial_dq;
-  d->fXjda_dq.noalias() = fdata.fXj * d->a_partial_dq;
-  d->fXjda_dv.noalias() = fdata.fXj * d->a_partial_dv;
+  d->fXjdv_dq.noalias() = fdata.fXj * fdata.v_partial_dq;
+  d->fXjda_dq.noalias() = fdata.fXj * fdata.a_partial_dq;
+  d->fXjda_dv.noalias() = fdata.fXj * fdata.a_partial_dv;
   d->da0_local_dx.leftCols(nv) = d->fXjda_dq.template topRows<3>();
   d->da0_local_dx.leftCols(nv).noalias() +=
       d->vw_skew * d->fXjdv_dq.template topRows<3>();
@@ -133,26 +133,26 @@ void ContactModel3DTpl<Scalar>::calcDiff(
       d->vv_skew * d->fXjdv_dq.template bottomRows<3>();
   d->da0_local_dx.rightCols(nv) = d->fXjda_dv.template topRows<3>();
   d->da0_local_dx.rightCols(nv).noalias() +=
-      d->vw_skew * d->fJf.template topRows<3>();
+      d->vw_skew * fdata.fJf.template topRows<3>();
   d->da0_local_dx.rightCols(nv).noalias() -=
-      d->vv_skew * d->fJf.template bottomRows<3>();
+      d->vv_skew * fdata.fJf.template bottomRows<3>();
   const Eigen::Ref<const Matrix3s> oRf =
       d->pinocchio->oMf[id_[0]].rotation();
 
   if (gains_[0] != 0.) {
     pinocchio::skew(d->dp_local, d->dp_skew);
     d->da0_local_dx.leftCols(nv).noalias() +=
-        gains_[0] * d->dp_skew * d->fJf.template bottomRows<3>();
+        gains_[0] * d->dp_skew * fdata.fJf.template bottomRows<3>();
     d->da0_local_dx.leftCols(nv).noalias() +=
-        gains_[0] * d->fJf.template topRows<3>();
+        gains_[0] * fdata.fJf.template topRows<3>();
   }
   if (gains_[1] != 0.) {
     d->da0_local_dx.leftCols(nv).noalias() +=
         gains_[1] * d->fXjdv_dq.template topRows<3>();
     d->da0_local_dx.rightCols(nv).noalias() +=
-        gains_[1] * d->fJf.template topRows<3>();
+        gains_[1] * fdata.fJf.template topRows<3>();
   }
-  switch (type_[0]) {
+  switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
       d->da0_dx = d->da0_local_dx;
       break;
@@ -176,7 +176,7 @@ void ContactModel3DTpl<Scalar>::calcDiff(
       d->a0_world_skew.noalias() = d->a0_skew * oRf;
       d->da0_dx.noalias() = oRf * d->da0_local_dx;
       d->da0_dx.leftCols(nv).noalias() -=
-          d->a0_world_skew * d->fJf.template bottomRows<3>();
+          d->a0_world_skew * fdata.fJf.template bottomRows<3>();
       break;
   }
 }
@@ -192,7 +192,7 @@ void ContactModel3DTpl<Scalar>::updateForce(
   ForceDataAbstract& fdata = d->force_datas[0];  // there's only one force data
   fdata.f.linear() = force;
   fdata.f.angular().setZero();
-  switch (type_[0]) {
+  switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
       fdata.fext = fdata.jMf.act(fdata.f);
       data->dtau_dq.setZero();
@@ -205,9 +205,9 @@ void ContactModel3DTpl<Scalar>::updateForce(
       d->f_local.angular().setZero();
       fdata.fext = fdata.jMf.act(d->f_local);
       pinocchio::skew(d->f_local.linear(), d->f_skew);
-      d->fJf_df.noalias() = d->f_skew * d->fJf.template bottomRows<3>();
+      d->fJf_df.noalias() = d->f_skew * fdata.fJf.template bottomRows<3>();
       data->dtau_dq.noalias() =
-          -d->fJf.template topRows<3>().transpose() * d->fJf_df;
+          -fdata.fJf.template topRows<3>().transpose() * d->fJf_df;
       break;
   }
 }
@@ -222,7 +222,7 @@ ContactModel3DTpl<Scalar>::createData(pinocchio::DataTpl<Scalar>* const data) {
 template <typename Scalar>
 void ContactModel3DTpl<Scalar>::print(std::ostream& os) const {
   os << "ContactModel3D {frame=" << state_->get_pinocchio()->frames[id_[0]].name
-     << ", type=" << type_[0] << "}";
+     << ", type=" << type_ << "}";
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -142,26 +142,10 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   const Vector2s &get_gains() const;
 
   /**
-   * @brief Set the first contact frame parent joint
-   */
-  void set_joint1_id(const int joint1_id);
-
-  /**
    * @brief Set the first contact frame placement with respect to the parent
    * joint
    */
-  void set_joint1_placement(const SE3 &joint1_placement);
-
-  /**
-   * @brief Set the second contact frame parent joint
-   */
-  void set_joint2_id(const int joint2_id);
-
-  /**
-   * @brief Set the second contact frame placement with respect to the parent
-   * joint
-   */
-  void set_joint2_placement(const SE3 &joint2_placement);
+  void set_placement(const int force_index, const SE3& placement);
 
   /**
    * @brief Set the Baumgarte stabilization gains

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -231,7 +231,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactData6DLoopTpl(Model<Scalar> *const model,
                        pinocchio::DataTpl<Scalar> *const data)
-      : Base(model, data),
+      : Base(model, data, 2),
         v1_partial_dq(6, model->get_state()->get_nv()),
         f1_v1_partial_dq(6, model->get_state()->get_nv()),
         a1_partial_dq(6, model->get_state()->get_nv()),
@@ -299,26 +299,39 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
 
   using Base::a0;
   using Base::da0_dx;
-  using Base::df_du;
-  using Base::df_dx;
-  using Base::dtau_dq;
-  using Base::f;
-  using Base::Jc;
-  using Base::pinocchio;
+  using Base::force_datas;
 
+  // Joint 1 quantities
   Matrix6xs v1_partial_dq;
-  Matrix6xs f1_v1_partial_dq;
   Matrix6xs a1_partial_dq;
   Matrix6xs a1_partial_dv;
+  Matrix6xs f1_v1_partial_dq;
+  SE3 oMf1;   // Placement of the first contact frame in the world frame
+  Matrix6xs f1Jf1;
+  Matrix6xs j1Jj1;
+  SE3ActionMatrix f1Xj1;
+  Motion f1vf1;
+  Motion f1af1;
+  Force joint1_f;
+
+  // Joint 2 quantities
   Matrix6xs v2_partial_dq;
-  Matrix6xs f2_v2_partial_dq;
-  Matrix6xs f1_v2_partial_dq;
   Matrix6xs a2_partial_dq;
+  Matrix6xs a2_partial_dv;
+  Matrix6xs f2_v2_partial_dq;
   Matrix6xs f2_a2_partial_dq;
   Matrix6xs f2_a2_partial_dv;
-  Matrix6xs a2_partial_dv;
-  Matrix6xs __partial_da;
+  SE3 oMf2;   // Placement of the second contact frame in the world frame
+  Matrix6xs j2Jj2;
+  Matrix6xs f2Jf2;
+  SE3ActionMatrix f2Xj2;
+  Motion f2vf2;
+  Motion f2af2;
+  Force joint2_f;
 
+
+  Matrix6xs f1_v2_partial_dq;
+  Matrix6xs __partial_da;
   Matrix6xs da0_dq_t1;
   Matrix6xs da0_dq_t2;
   Matrix6xs da0_dq_t2_tmp;
@@ -329,31 +342,16 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs dvel_dq;
   MatrixXs dtau_dq_tmp;
   // Placement related data
-  SE3 oMf1;   // Placement of the first contact frame in the world frame
-  SE3 oMf2;   // Placement of the second contact frame in the world frame
   SE3 f1Mf2;  // Relative placement of the contact frames in the first contact
               // frame
-  SE3ActionMatrix f1Xj1;
-  SE3ActionMatrix f2Xj2;
   SE3ActionMatrix f1Xf2;
   // Jacobian related data
-  Matrix6xs f1Jf1;
-  Matrix6xs f2Jf2;
   Matrix6xs f1Jf2;
-  Matrix6xs j1Jj1;
-  Matrix6xs j2Jj2;
   Matrix6xs j2Jj1;
   // Velocity related data
-  Motion f1vf1;
-  Motion f2vf2;
   Motion f1vf2;
   // Acceleration related data
-  Motion f1af1;
-  Motion f2af2;
   Motion f1af2;
-  // Force related data
-  Force joint1_f;
-  Force joint2_f;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -226,6 +226,9 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     f1af1 = Motion::Zero();
     f2af2 = Motion::Zero();
     f1af2 = Motion::Zero();
+    //
+    joint1_f = Force::Zero();
+    joint2_f = Force::Zero();
   }
 
   using Base::a0;
@@ -269,6 +272,12 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Motion f1af1;
   Motion f2af2;
   Motion f1af2;
+  // Force related data
+  Force joint1_f;
+  Force joint2_f;
+  Force f_local;
+
+  Matrix6s f_cross;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -236,7 +236,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         f1_v1_partial_dq(6, model->get_state()->get_nv()),
         a1_partial_dq(6, model->get_state()->get_nv()),
         a1_partial_dv(6, model->get_state()->get_nv()),
-        a1_partial_da(6, model->get_state()->get_nv()),
         v2_partial_dq(6, model->get_state()->get_nv()),
         f2_v2_partial_dq(6, model->get_state()->get_nv()),
         f1_v2_partial_dq(6, model->get_state()->get_nv()),
@@ -244,7 +243,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         f2_a2_partial_dq(6, model->get_state()->get_nv()),
         f2_a2_partial_dv(6, model->get_state()->get_nv()),
         a2_partial_dv(6, model->get_state()->get_nv()),
-        a2_partial_da(6, model->get_state()->get_nv()),
+        __partial_da(6, model->get_state()->get_nv()),
         da0_dq_t1(6, model->get_state()->get_nv()),
         da0_dq_t2(6, model->get_state()->get_nv()),
         da0_dq_t2_tmp(6, model->get_state()->get_nv()),
@@ -274,7 +273,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     f1_v1_partial_dq.setZero();
     a1_partial_dq.setZero();
     a1_partial_dv.setZero();
-    a1_partial_da.setZero();
     v2_partial_dq.setZero();
     f2_v2_partial_dq.setZero();
     f1_v2_partial_dq.setZero();
@@ -282,7 +280,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     f2_a2_partial_dq.setZero();
     f2_a2_partial_dv.setZero();
     a2_partial_dv.setZero();
-    a2_partial_da.setZero();
+    __partial_da.setZero();
     da0_dq_t1.setZero();
     da0_dq_t2.setZero();
     da0_dq_t2_tmp.setZero();
@@ -312,7 +310,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs f1_v1_partial_dq;
   Matrix6xs a1_partial_dq;
   Matrix6xs a1_partial_dv;
-  Matrix6xs a1_partial_da;
   Matrix6xs v2_partial_dq;
   Matrix6xs f2_v2_partial_dq;
   Matrix6xs f1_v2_partial_dq;
@@ -320,7 +317,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs f2_a2_partial_dq;
   Matrix6xs f2_a2_partial_dv;
   Matrix6xs a2_partial_dv;
-  Matrix6xs a2_partial_da;
+  Matrix6xs __partial_da;
 
   Matrix6xs da0_dq_t1;
   Matrix6xs da0_dq_t2;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -257,8 +257,8 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         f1Jf2(6, model->get_state()->get_nv()),
         j1Jj1(6, model->get_state()->get_nv()),
         j2Jj2(6, model->get_state()->get_nv()),
-        j1Xf1(SE3ActionMatrix::Identity()),
-        j2Xf2(SE3ActionMatrix::Identity()),
+        f1Xj1(model->get_joint1_placement().inverse()),
+        f2Xj2(model->get_joint2_placement().inverse()),
         f1Mf2(SE3::Identity()),
         f1Xf2(SE3ActionMatrix::Identity()),
         f1vf1(Motion::Zero()),
@@ -333,8 +333,8 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   SE3 oMf2;   // Placement of the second contact frame in the world frame
   SE3 f1Mf2;  // Relative placement of the contact frames in the first contact
               // frame
-  SE3ActionMatrix j1Xf1;
-  SE3ActionMatrix j2Xf2;
+  SE3ActionMatrix f1Xj1;
+  SE3ActionMatrix f2Xj2;
   SE3ActionMatrix f1Xf2;
   // Jacobian related data
   Matrix6xs f1Jf1;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -42,37 +42,37 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
    * @brief Initialize the 6d contact model from joint and placements
    *
    *
-   * @param[in] state  State of the multibody system
-   * @param[in] joint1_id     Reference joint id of the first contact
-   * @param[in] joint1_placement     Placement of the first contact with respect
-   * to the joint
-   * @param[in] joint2_id     Reference joint id of the second contact
-   * @param[in] joint2_placement     Placement of the second contact with
-   * respect to the joint
-   * @param[in] ref    Reference frame of contact
-   * @param[in] nu     Dimension of the control vector
-   * @param[in] gains  Baumgarte stabilization gains
+   * @param[in] state             State of the multibody system
+   * @param[in] joint1_id         Parent joint id of the first contact
+   * @param[in] joint1_placement  Placement of the first contact with
+   *                                  respect to the parent joint
+   * @param[in] joint2_id         Parent joint id of the second contact
+   * @param[in] joint2_placement  Placement of the second contact with
+   *                                  respect to the parent joint
+   * @param[in] ref               Reference frame of contact
+   * @param[in] nu                Dimension of the control vector
+   * @param[in] gains             Baumgarte stabilization gains
    */
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
                         const int joint2_id, const SE3 &joint2_placement,
                         const pinocchio::ReferenceFrame ref,
                         const std::size_t nu,
-                        const Vector2s &gains = Vector2s());
+                        const Vector2s &gains = Vector2s::Zero());
 
   /**
    * @brief Initialize the 6d contact model from joint and placements
    *
    *
-   * @param[in] state  State of the multibody system
-   * @param[in] joint1_id     Reference joint id of the first contact
-   * @param[in] joint1_placement     Placement of the first contact with respect
-   * to the joint
-   * @param[in] joint2_id     Reference joint id of the second contact
-   * @param[in] joint2_placement     Placement of the second contact with
-   * respect to the joint
-   * @param[in] ref    Reference frame of contact
-   * @param[in] gains  Baumgarte stabilization gains
+   * @param[in] state             State of the multibody system
+   * @param[in] joint1_id         Parent joint id of the first contact
+   * @param[in] joint1_placement  Placement of the first contact with
+   *                                  respect to the parent joint
+   * @param[in] joint2_id         Parent joint id of the second contact
+   * @param[in] joint2_placement  Placement of the second contact with
+   *                                  respect to the parent joint
+   * @param[in] ref               Reference frame of contact
+   * @param[in] gains             Baumgarte stabilization gains
    */
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
@@ -118,22 +118,22 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
       pinocchio::DataTpl<Scalar> *const data);
 
   /**
-   * @brief Return the reference the first contact frame parent joint
+   * @brief Return the first contact frame parent joint
    */
   const int get_joint1_id() const;
 
   /**
-   * @brief Return the reference the first contact frame placement
+   * @brief Return the first contact frame placement with respect to the parent joint
    */
   const SE3 &get_joint1_placement() const;
 
   /**
-   * @brief Return the reference the second contact frame parent joint
+   * @brief Return the second contact frame parent joint
    */
   const int get_joint2_id() const;
 
   /**
-   * @brief Return the reference the second contact frame placement
+   * @brief Return the second contact frame placement with respect to the parent joint
    */
   const SE3 &get_joint2_placement() const;
 
@@ -143,22 +143,22 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   const Vector2s &get_gains() const;
 
   /**
-   * @brief Set the reference the first contact frame parent joint
+   * @brief Set the first contact frame parent joint
    */
   void set_joint1_id(const int joint1_id);
 
   /**
-   * @brief Set the reference the first contact frame placement
+   * @brief Set the first contact frame placement with respect to the parent joint
    */
   void set_joint1_placement(const SE3 &joint1_placement);
 
   /**
-   * @brief Set the reference the second contact frame parent joint
+   * @brief Set the second contact frame parent joint
    */
   void set_joint2_id(const int joint2_id);
 
   /**
-   * @brief Set the reference the second contact frame placement
+   * @brief Set the second contact frame placement with respect to the parent joint
    */
   void set_joint2_placement(const SE3 &joint2_placement);
 
@@ -168,7 +168,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   void set_gains(const Vector2s &gains);
 
   /**
-   * @brief Print relevant information of the 6d contact model
+   * @brief Print relevant information of the 6D loop-contact model
    *
    * @param[out] os  Output stream object
    */
@@ -182,12 +182,12 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   using Base::type_;
 
  private:
-  int joint1_id_;         //!< Reference joint id of the first contact
+  int joint1_id_;         //!< Parent joint id of the first contact
   SE3 joint1_placement_;  //!< Placement of the first contact with respect to
-                          //!< the joint
-  int joint2_id_;         //!< Reference joint id of the second contact
+                          //!< the parent joint
+  int joint2_id_;         //!< Parent joint id of the second contact
   SE3 joint2_placement_;  //!< Placement of the second contact with respect to
-                          //!< the joint
+                          //!< the parent joint
   Vector2s gains_;        //!< Baumgarte stabilization gains
 };
 
@@ -217,8 +217,11 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         a1_partial_dv(6, model->get_state()->get_nv()),
         a1_partial_da(6, model->get_state()->get_nv()),
         v2_partial_dq(6, model->get_state()->get_nv()),
+        f2_v2_partial_dq(6, model->get_state()->get_nv()),
+        f1_v2_partial_dq(6, model->get_state()->get_nv()),
         a2_partial_dq(6, model->get_state()->get_nv()),
         f2_a2_partial_dq(6, model->get_state()->get_nv()),
+        f2_a2_partial_dv(6, model->get_state()->get_nv()),
         a2_partial_dv(6, model->get_state()->get_nv()),
         a2_partial_da(6, model->get_state()->get_nv()),
         da0_dq_t1(6, model->get_state()->get_nv()),
@@ -226,6 +229,8 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         da0_dq_t2_tmp(6, model->get_state()->get_nv()),
         da0_dq_t3(6, model->get_state()->get_nv()),
         da0_dq_t3_tmp(6, model->get_state()->get_nv()),
+        dpos_dq(6, model->get_state()->get_nv()),
+        dvel_dq(6, model->get_state()->get_nv()),
         f1Jf1(6, model->get_state()->get_nv()),
         f2Jf2(6, model->get_state()->get_nv()),
         f1Jf2(6, model->get_state()->get_nv()),
@@ -237,8 +242,11 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     a1_partial_dv.setZero();
     a1_partial_da.setZero();
     v2_partial_dq.setZero();
+    f2_v2_partial_dq.setZero();
+    f1_v2_partial_dq.setZero();
     a2_partial_dq.setZero();
     f2_a2_partial_dq.setZero();
+    f2_a2_partial_dv.setZero();
     a2_partial_dv.setZero();
     a2_partial_da.setZero();
     da0_dq_t1.setZero();
@@ -246,6 +254,8 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     da0_dq_t2_tmp.setZero();
     da0_dq_t3.setZero();
     da0_dq_t3_tmp.setZero();
+    dpos_dq.setZero();
+    dvel_dq.setZero();
     f1Jf1.setZero();
     f2Jf2.setZero();
     f1Jf2.setZero();
@@ -284,8 +294,11 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs a1_partial_dv;
   Matrix6xs a1_partial_da;
   Matrix6xs v2_partial_dq;
+  Matrix6xs f2_v2_partial_dq;
+  Matrix6xs f1_v2_partial_dq;
   Matrix6xs a2_partial_dq;
   Matrix6xs f2_a2_partial_dq;
+  Matrix6xs f2_a2_partial_dv;
   Matrix6xs a2_partial_dv;
   Matrix6xs a2_partial_da;
 
@@ -295,10 +308,12 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs da0_dq_t3;
   Matrix6xs da0_dq_t3_tmp;
 
+  Matrix6xs dpos_dq;
+  Matrix6xs dvel_dq;
   // Placement related data
   SE3 oMf1;   // Placement of the first contact frame in the world frame
   SE3 oMf2;   // Placement of the second contact frame in the world frame
-  SE3 f1Mf2;  // Relative placement of the contact frames in f1 frame
+  SE3 f1Mf2;  // Relative placement of the contact frames in the first contact frame
   SE3ActionMatrix j1Xf1;
   SE3ActionMatrix j2Xf2;
   SE3ActionMatrix f1Xf2;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -50,14 +50,14 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] joint2_id         Parent joint id of the second contact
    * @param[in] joint2_placement  Placement of the second contact with
    *                                  respect to the parent joint
-   * @param[in] ref               Reference frame of contact
+   * @param[in] type              Reference frame of contact
    * @param[in] nu                Dimension of the control vector
    * @param[in] gains             Baumgarte stabilization gains
    */
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
                         const int joint2_id, const SE3 &joint2_placement,
-                        const pinocchio::ReferenceFrame ref,
+                        const pinocchio::ReferenceFrame type
                         const std::size_t nu,
                         const Vector2s &gains = Vector2s::Zero());
 
@@ -72,13 +72,13 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] joint2_id         Parent joint id of the second contact
    * @param[in] joint2_placement  Placement of the second contact with
    *                                  respect to the parent joint
-   * @param[in] ref               Reference frame of contact
+   * @param[in] type              Reference frame of contact
    * @param[in] gains             Baumgarte stabilization gains
    */
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
                         const int joint2_id, const SE3 &joint2_placement,
-                        const pinocchio::ReferenceFrame ref,
+                        const pinocchio::ReferenceFrame type
                         const Vector2s &gains = Vector2s::Zero());
 
   virtual ~ContactModel6DLoopTpl();

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -58,7 +58,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
       boost::shared_ptr<StateMultibody> state, const int joint1_id,
       const SE3 &joint1_placement, const int joint2_id,
       const SE3 &joint2_placement,
-      const pinocchio::ReferenceFrame type const std::size_t nu,
+      const pinocchio::ReferenceFrame type, const std::size_t nu,
       const Vector2s &gains = Vector2s::Zero());
 
   /**
@@ -78,7 +78,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
                         const int joint2_id, const SE3 &joint2_placement,
-                        const pinocchio::ReferenceFrame type const Vector2s
+                        const pinocchio::ReferenceFrame type, const Vector2s
                             &gains = Vector2s::Zero());
 
   virtual ~ContactModel6DLoopTpl();

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -192,24 +192,17 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   ContactData6DLoopTpl(Model<Scalar> *const model,
                        pinocchio::DataTpl<Scalar> *const data)
       : Base(model, data, 2),
-        f1_v2_partial_dq(6, model->get_state()->get_nv()),
         da0_dq_t1(6, model->get_state()->get_nv()),
         da0_dq_t2(6, model->get_state()->get_nv()),
-        da0_dq_t2_tmp(6, model->get_state()->get_nv()),
         da0_dq_t3(6, model->get_state()->get_nv()),
-        da0_dq_t3_tmp(6, model->get_state()->get_nv()),
-        dpos_dq(6, model->get_state()->get_nv()),
-        dvel_dq(6, model->get_state()->get_nv()),
-        dtau_dq_tmp(model->get_state()->get_nv(), model->get_state()->get_nv()),
-        f1Jf2(6, model->get_state()->get_nv()),
         f1Mf2(SE3::Identity()),
         f1Xf2(SE3ActionMatrix::Identity()),
         f1vf2(Motion::Zero()),
-        f1af2(Motion::Zero()) {
-    if (force_datas.size() != 2 || nf != 2) {
+        f1af2(Motion::Zero()),
+        f_cross(6, 6) {
+    if (force_datas.size() != 2 || nf != 2)
       throw_pretty(
           "Invalid argument: " << "the force_datas has to be of size 2");
-    }
 
     ForceDataAbstract &fdata1 = force_datas[0];
     fdata1.frame = model->get_id(0);
@@ -223,17 +216,10 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     fdata2.fXj = fdata2.jMf.inverse().toActionMatrix();
     fdata2.type = model->get_type();
 
-    f1_v2_partial_dq.setZero();
     da0_dq_t1.setZero();
     da0_dq_t2.setZero();
-    da0_dq_t2_tmp.setZero();
     da0_dq_t3.setZero();
-    da0_dq_t3_tmp.setZero();
-    dpos_dq.setZero();
-    dvel_dq.setZero();
-    dtau_dq_tmp.setZero();
-    f1Jf2.setZero();
-    j2Jj1.setZero();
+    f_cross.setZero();
   }
 
   using Base::a0;
@@ -244,23 +230,15 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   // Intermediate calculations
   Matrix6xs da0_dq_t1;
   Matrix6xs da0_dq_t2;
-  Matrix6xs da0_dq_t2_tmp;
   Matrix6xs da0_dq_t3;
-  Matrix6xs da0_dq_t3_tmp;
-  Matrix6xs dpos_dq;
-  Matrix6xs dvel_dq;
-  MatrixXs dtau_dq_tmp;
 
   // Coupled terms
-  SE3 f1Mf2;  //<! Relative placement of the contact frames in the first contact
-              // frame
+  SE3 f1Mf2;
   SE3ActionMatrix f1Xf2;  //<! Relative action matrix of the
                           // contact frames in the first contact frame
   Motion f1vf2;
   Motion f1af2;
-  Matrix6xs f1Jf2;
-  Matrix6xs j2Jj1;
-  Matrix6xs f1_v2_partial_dq;
+  Matrix6s f_cross;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -40,7 +40,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   /**
-   * @brief Initialize the 6d contact model from joint and placements
+   * @brief Initialize the 6d loop-contact model from joint and placements
    *
    *
    * @param[in] state             State of the multibody system
@@ -62,7 +62,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
                         const Vector2s &gains = Vector2s::Zero());
 
   /**
-   * @brief Initialize the 6d contact model from joint and placements
+   * @brief Initialize the 6d loop-contact model from joint and placements
    *
    *
    * @param[in] state             State of the multibody system
@@ -84,9 +84,9 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   virtual ~ContactModel6DLoopTpl();
 
   /**
-   * @brief Compute the 3d contact Jacobian and drift
+   * @brief Compute the 6d loop-contact Jacobian and drift
    *
-   * @param[in] data  3d contact data
+   * @param[in] data  6d loop-contact data
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
@@ -94,9 +94,9 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
                     const Eigen::Ref<const VectorXs> &x);
 
   /**
-   * @brief Compute the derivatives of the 6d contact holonomic constraint
+   * @brief Compute the derivatives of the 6d loop-contact holonomic constraint
    *
-   * @param[in] data  6d contact data
+   * @param[in] data  6d loop-contact data
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
@@ -106,7 +106,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   /**
    * @brief Convert the force into a stack of spatial forces
    *
-   * @param[in] data   6d contact data
+   * @param[in] data   6d loop-contact data
    * @param[in] force  6d force
    */
   virtual void updateForce(const boost::shared_ptr<ContactDataAbstract> &data,
@@ -126,7 +126,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
                                const MatrixXs& df_dx, const MatrixXs& df_du);
 
   /**
-   * @brief Create the 6d contact data
+   * @brief Create the 6d loop-contact data
    */
   virtual boost::shared_ptr<ContactDataAbstract> createData(
       pinocchio::DataTpl<Scalar> *const data);
@@ -250,7 +250,19 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         f2Jf2(6, model->get_state()->get_nv()),
         f1Jf2(6, model->get_state()->get_nv()),
         j1Jj1(6, model->get_state()->get_nv()),
-        j2Jj2(6, model->get_state()->get_nv()) {
+        j2Jj2(6, model->get_state()->get_nv()),
+        j1Xf1(SE3ActionMatrix::Identity()),
+        j2Xf2(SE3ActionMatrix::Identity()),
+        f1Mf2(SE3::Identity()),
+        f1Xf2(SE3ActionMatrix::Identity()),
+        f1vf1(Motion::Zero()),
+        f2vf2(Motion::Zero()),
+        f1vf2(Motion::Zero()),
+        f1af1(Motion::Zero()),
+        f2af2(Motion::Zero()),
+        f1af2(Motion::Zero()),
+        joint1_f(Force::Zero()),
+        joint2_f(Force::Zero()) {
     v1_partial_dq.setZero();
     f1_v1_partial_dq.setZero();
     a1_partial_dq.setZero();
@@ -278,22 +290,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     j1Jj1.setZero();
     j2Jj2.setZero();
     j2Jj1.setZero();
-    //
-    j1Xf1 = SE3ActionMatrix::Identity();
-    j2Xf2 = SE3ActionMatrix::Identity();
-    f1Mf2 = SE3::Identity();
-    f1Xf2 = SE3ActionMatrix::Identity();
-    //
-    f1vf1 = Motion::Zero();
-    f2vf2 = Motion::Zero();
-    f1vf2 = Motion::Zero();
-    //
-    f1af1 = Motion::Zero();
-    f2af2 = Motion::Zero();
-    f1af2 = Motion::Zero();
-    //
-    joint1_f = Force::Zero();
-    joint2_f = Force::Zero();
   }
 
   using Base::a0;
@@ -353,7 +349,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   // Force related data
   Force joint1_f;
   Force joint2_f;
-  Force f_local;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -1,0 +1,280 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_LOOP_HPP_
+#define CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_LOOP_HPP_
+
+#include <pinocchio/multibody/data.hpp>
+#include <pinocchio/spatial/motion.hpp>
+
+#include "crocoddyl/core/utils/deprecate.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/multibody/fwd.hpp"
+
+namespace crocoddyl {
+
+template <typename _Scalar>
+class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ContactModelAbstractTpl<Scalar> Base;
+  typedef ContactData6DLoopTpl<Scalar> Data;
+  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef ContactDataAbstractTpl<Scalar> ContactDataAbstract;
+  typedef pinocchio::SE3Tpl<Scalar> SE3;
+  typedef pinocchio::ForceTpl<Scalar> Force;
+  typedef typename MathBase::Vector2s Vector2s;
+  typedef typename MathBase::Vector3s Vector3s;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::Matrix3s Matrix3s;
+  typedef typename MathBase::Matrix6s Matrix6s;
+
+  /**
+   * @brief Initialize the 6d contact model from joint and placements
+   *
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] joint1_id     Reference joint id of the first contact
+   * @param[in] joint1_placement     Placement of the first contact with respect
+   * to the joint
+   * @param[in] joint2_id     Reference joint id of the second contact
+   * @param[in] joint2_placement     Placement of the second contact with
+   * respect to the joint
+   * @param[in] ref    Reference frame of contact
+   * @param[in] nu     Dimension of the control vector
+   * @param[in] gains  Baumgarte stabilization gains
+   */
+  ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
+                        const int joint1_id, const SE3 &joint1_placement,
+                        const int joint2_id, const SE3 &joint2_placement,
+                        const pinocchio::ReferenceFrame ref,
+                        const std::size_t nu,
+                        const Vector2s &gains = Vector2s());
+
+  /**
+   * @brief Initialize the 6d contact model from joint and placements
+   *
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] joint1_id     Reference joint id of the first contact
+   * @param[in] joint1_placement     Placement of the first contact with respect
+   * to the joint
+   * @param[in] joint2_id     Reference joint id of the second contact
+   * @param[in] joint2_placement     Placement of the second contact with
+   * respect to the joint
+   * @param[in] ref    Reference frame of contact
+   * @param[in] gains  Baumgarte stabilization gains
+   */
+  ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
+                        const int joint1_id, const SE3 &joint1_placement,
+                        const int joint2_id, const SE3 &joint2_placement,
+                        const pinocchio::ReferenceFrame ref,
+                        const Vector2s &gains = Vector2s::Zero());
+
+  virtual ~ContactModel6DLoopTpl();
+
+  /**
+   * @brief Compute the 3d contact Jacobian and drift
+   *
+   * @param[in] data  3d contact data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calc(const boost::shared_ptr<ContactDataAbstract> &data,
+                    const Eigen::Ref<const VectorXs> &x);
+
+  /**
+   * @brief Compute the derivatives of the 6d contact holonomic constraint
+   *
+   * @param[in] data  6d contact data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calcDiff(const boost::shared_ptr<ContactDataAbstract> &data,
+                        const Eigen::Ref<const VectorXs> &x);
+
+  /**
+   * @brief Convert the force into a stack of spatial forces
+   *
+   * @param[in] data   6d contact data
+   * @param[in] force  6d force
+   */
+  virtual void updateForce(const boost::shared_ptr<ContactDataAbstract> &data,
+                           const VectorXs &force);
+
+  /**
+   * @brief Create the 6d contact data
+   */
+  virtual boost::shared_ptr<ContactDataAbstract> createData(
+      pinocchio::DataTpl<Scalar> *const data);
+
+  /**
+   * @brief Return the reference the first contact frame parent joint
+   */
+  const int get_joint1_id() const;
+
+  /**
+   * @brief Return the reference the first contact frame placement
+   */
+  const SE3 &get_joint1_placement() const;
+
+  /**
+   * @brief Return the reference the second contact frame parent joint
+   */
+  const int get_joint2_id() const;
+
+  /**
+   * @brief Return the reference the second contact frame placement
+   */
+  const SE3 &get_joint2_placement() const;
+
+  /**
+   * @brief Return the Baumgarte stabilization gains
+   */
+  const Vector2s &get_gains() const;
+
+  /**
+   * @brief Print relevant information of the 6d contact model
+   *
+   * @param[out] os  Output stream object
+   */
+  virtual void print(std::ostream &os) const;
+
+ protected:
+  using Base::id_;
+  using Base::nc_;
+  using Base::nu_;
+  using Base::state_;
+  using Base::type_;
+
+ private:
+  int joint1_id_;         //!< Reference joint id of the first contact
+  SE3 joint1_placement_;  //!< Placement of the first contact with respect to
+                          //!< the joint
+  int joint2_id_;         //!< Reference joint id of the second contact
+  SE3 joint2_placement_;  //!< Placement of the second contact with respect to
+                          //!< the joint
+  Vector2s gains_;  //!< Baumgarte stabilization gains
+};
+
+template <typename _Scalar>
+struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ContactDataAbstractTpl<Scalar> Base;
+  typedef typename MathBase::Matrix3s Matrix3s;
+  typedef typename MathBase::Matrix6xs Matrix6xs;
+  typedef typename MathBase::Matrix6s Matrix6s;
+  typedef typename MathBase::MatrixXs MatrixXs;
+  typedef typename pinocchio::SE3Tpl<Scalar> SE3;
+  typedef typename pinocchio::SE3Tpl<Scalar>::ActionMatrixType SE3ActionMatrix;
+  typedef typename pinocchio::MotionTpl<Scalar> Motion;
+  typedef typename pinocchio::ForceTpl<Scalar> Force;
+
+  template <template <typename Scalar> class Model>
+  ContactData6DLoopTpl(Model<Scalar> *const model,
+                       pinocchio::DataTpl<Scalar> *const data)
+      : Base(model, data),
+        v1_partial_dq(6, model->get_state()->get_nv()),
+        a1_partial_dq(6, model->get_state()->get_nv()),
+        a1_partial_dv(6, model->get_state()->get_nv()),
+        a1_partial_da(6, model->get_state()->get_nv()),
+        v2_partial_dq(6, model->get_state()->get_nv()),
+        a2_partial_dq(6, model->get_state()->get_nv()),
+        a2_partial_dv(6, model->get_state()->get_nv()),
+        a2_partial_da(6, model->get_state()->get_nv()),
+        da0_dq_t1(6, model->get_state()->get_nv()),
+        da0_dq_t2(6, model->get_state()->get_nv()),
+        da0_dq_t3(6, model->get_state()->get_nv()) {
+    v1_partial_dq.setZero();
+    a1_partial_dq.setZero();
+    a1_partial_dv.setZero();
+    a1_partial_da.setZero();
+    v2_partial_dq.setZero();
+    a2_partial_dq.setZero();
+    a2_partial_dv.setZero();
+    a2_partial_da.setZero();
+    da0_dq_t1.setZero();
+    da0_dq_t2.setZero();
+    da0_dq_t3.setZero();
+    //
+    j1Xf1 = SE3ActionMatrix::Identity();
+    j2Xf2 = SE3ActionMatrix::Identity();
+    f1Mf2 = SE3::Identity();
+    f1Xf2 = SE3ActionMatrix::Identity();
+    //
+    f1Jf1 = MatrixXs::Zero(6, model->get_state()->get_nv());
+    f2Jf2 = MatrixXs::Zero(6, model->get_state()->get_nv());
+    j1Jj1 = MatrixXs::Zero(6, model->get_state()->get_nv());
+    j2Jj2 = MatrixXs::Zero(6, model->get_state()->get_nv());
+    //
+    f1vf1 = Motion::Zero();
+    f2vf2 = Motion::Zero();
+    f1vf2 = Motion::Zero();
+    //
+    f1af1 = Motion::Zero();
+    f2af2 = Motion::Zero();
+    f1af2 = Motion::Zero();
+  }
+
+  using Base::a0;
+  using Base::da0_dx;
+  using Base::df_du;
+  using Base::df_dx;
+  using Base::f;
+  using Base::Jc;
+  using Base::pinocchio;
+
+  Matrix6xs v1_partial_dq;
+  Matrix6xs a1_partial_dq;
+  Matrix6xs a1_partial_dv;
+  Matrix6xs a1_partial_da;
+  Matrix6xs v2_partial_dq;
+  Matrix6xs a2_partial_dq;
+  Matrix6xs a2_partial_dv;
+  Matrix6xs a2_partial_da;
+
+  Matrix6xs da0_dq_t1;
+  Matrix6xs da0_dq_t2;
+  Matrix6xs da0_dq_t3;
+
+  // Placement related data
+  SE3 oMf1;   // Placement of the first contact frame in the world frame
+  SE3 oMf2;   // Placement of the second contact frame in the world frame
+  SE3 f1Mf2;  // Relative placement of the contact frames in f1 frame
+  SE3ActionMatrix j1Xf1;
+  SE3ActionMatrix j2Xf2;
+  SE3ActionMatrix f1Xf2;
+  // Jacobian related data
+  MatrixXs f1Jf1;
+  MatrixXs f2Jf2;
+  MatrixXs j1Jj1;
+  MatrixXs j2Jj2;
+  // Velocity related data
+  Motion f1vf1;
+  Motion f2vf2;
+  Motion f1vf2;
+  // Acceleration related data
+  Motion f1af1;
+  Motion f2af2;
+  Motion f1af2;
+};
+
+}  // namespace crocoddyl
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+#include "crocoddyl/multibody/contacts/contact-6d-loop.hxx"
+
+#endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_LOOP_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -245,6 +245,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
         da0_dq_t3_tmp(6, model->get_state()->get_nv()),
         dpos_dq(6, model->get_state()->get_nv()),
         dvel_dq(6, model->get_state()->get_nv()),
+        dtau_dq_tmp(model->get_state()->get_nv(), model->get_state()->get_nv()),
         f1Jf1(6, model->get_state()->get_nv()),
         f2Jf2(6, model->get_state()->get_nv()),
         f1Jf2(6, model->get_state()->get_nv()),
@@ -270,11 +271,13 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
     da0_dq_t3_tmp.setZero();
     dpos_dq.setZero();
     dvel_dq.setZero();
+    dtau_dq_tmp.setZero();
     f1Jf1.setZero();
     f2Jf2.setZero();
     f1Jf2.setZero();
     j1Jj1.setZero();
     j2Jj2.setZero();
+    j2Jj1.setZero();
     //
     j1Xf1 = SE3ActionMatrix::Identity();
     j2Xf2 = SE3ActionMatrix::Identity();
@@ -324,6 +327,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
 
   Matrix6xs dpos_dq;
   Matrix6xs dvel_dq;
+  MatrixXs dtau_dq_tmp;
   // Placement related data
   SE3 oMf1;   // Placement of the first contact frame in the world frame
   SE3 oMf2;   // Placement of the second contact frame in the world frame
@@ -337,6 +341,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Matrix6xs f1Jf2;
   Matrix6xs j1Jj1;
   Matrix6xs j2Jj2;
+  Matrix6xs j2Jj1;
   // Velocity related data
   Motion f1vf1;
   Motion f2vf2;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -235,6 +235,7 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   using Base::da0_dx;
   using Base::df_du;
   using Base::df_dx;
+  using Base::dtau_dq;
   using Base::f;
   using Base::Jc;
   using Base::pinocchio;
@@ -276,8 +277,6 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   Force joint1_f;
   Force joint2_f;
   Force f_local;
-
-  Matrix6s f_cross;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -163,7 +163,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   int joint2_id_;         //!< Reference joint id of the second contact
   SE3 joint2_placement_;  //!< Placement of the second contact with respect to
                           //!< the joint
-  Vector2s gains_;  //!< Baumgarte stabilization gains
+  Vector2s gains_;        //!< Baumgarte stabilization gains
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -54,12 +54,12 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] nu                Dimension of the control vector
    * @param[in] gains             Baumgarte stabilization gains
    */
-  ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
-                        const int joint1_id, const SE3 &joint1_placement,
-                        const int joint2_id, const SE3 &joint2_placement,
-                        const pinocchio::ReferenceFrame type
-                        const std::size_t nu,
-                        const Vector2s &gains = Vector2s::Zero());
+  ContactModel6DLoopTpl(
+      boost::shared_ptr<StateMultibody> state, const int joint1_id,
+      const SE3 &joint1_placement, const int joint2_id,
+      const SE3 &joint2_placement,
+      const pinocchio::ReferenceFrame type const std::size_t nu,
+      const Vector2s &gains = Vector2s::Zero());
 
   /**
    * @brief Initialize the 6d loop-contact model from joint and placements
@@ -78,8 +78,8 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   ContactModel6DLoopTpl(boost::shared_ptr<StateMultibody> state,
                         const int joint1_id, const SE3 &joint1_placement,
                         const int joint2_id, const SE3 &joint2_placement,
-                        const pinocchio::ReferenceFrame type
-                        const Vector2s &gains = Vector2s::Zero());
+                        const pinocchio::ReferenceFrame type const Vector2s
+                            &gains = Vector2s::Zero());
 
   virtual ~ContactModel6DLoopTpl();
 

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -37,6 +37,7 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::Matrix3s Matrix3s;
   typedef typename MathBase::Matrix6s Matrix6s;
+  typedef typename MathBase::MatrixXs MatrixXs;
 
   /**
    * @brief Initialize the 6d contact model from joint and placements
@@ -110,6 +111,19 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   virtual void updateForce(const boost::shared_ptr<ContactDataAbstract> &data,
                            const VectorXs &force);
+
+
+  /**
+   * @brief Updates the force differential for the given contact data.
+   *
+   * This function updates the force differential matrices with respect to the state and control variables.
+   *
+   * @param[in] data  Shared pointer to the contact data abstract.
+   * @param[in] df_dx Matrix representing the differential of the force with respect to the state variables.
+   * @param[in] df_du Matrix representing the differential of the force with respect to the control variables.
+   */
+  virtual void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data,
+                               const MatrixXs& df_dx, const MatrixXs& df_du);
 
   /**
    * @brief Create the 6d contact data

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hpp
@@ -112,18 +112,21 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   virtual void updateForce(const boost::shared_ptr<ContactDataAbstract> &data,
                            const VectorXs &force);
 
-
   /**
    * @brief Updates the force differential for the given contact data.
    *
-   * This function updates the force differential matrices with respect to the state and control variables.
+   * This function updates the force differential matrices with respect to the
+   * state and control variables.
    *
    * @param[in] data  Shared pointer to the contact data abstract.
-   * @param[in] df_dx Matrix representing the differential of the force with respect to the state variables.
-   * @param[in] df_du Matrix representing the differential of the force with respect to the control variables.
+   * @param[in] df_dx Matrix representing the differential of the force with
+   * respect to the state variables.
+   * @param[in] df_du Matrix representing the differential of the force with
+   * respect to the control variables.
    */
-  virtual void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data,
-                               const MatrixXs& df_dx, const MatrixXs& df_du);
+  virtual void updateForceDiff(
+      const boost::shared_ptr<ContactDataAbstract> &data, const MatrixXs &df_dx,
+      const MatrixXs &df_du);
 
   /**
    * @brief Create the 6d loop-contact data
@@ -137,7 +140,8 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   const int get_joint1_id() const;
 
   /**
-   * @brief Return the first contact frame placement with respect to the parent joint
+   * @brief Return the first contact frame placement with respect to the parent
+   * joint
    */
   const SE3 &get_joint1_placement() const;
 
@@ -147,7 +151,8 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   const int get_joint2_id() const;
 
   /**
-   * @brief Return the second contact frame placement with respect to the parent joint
+   * @brief Return the second contact frame placement with respect to the parent
+   * joint
    */
   const SE3 &get_joint2_placement() const;
 
@@ -162,7 +167,8 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   void set_joint1_id(const int joint1_id);
 
   /**
-   * @brief Set the first contact frame placement with respect to the parent joint
+   * @brief Set the first contact frame placement with respect to the parent
+   * joint
    */
   void set_joint1_placement(const SE3 &joint1_placement);
 
@@ -172,7 +178,8 @@ class ContactModel6DLoopTpl : public ContactModelAbstractTpl<_Scalar> {
   void set_joint2_id(const int joint2_id);
 
   /**
-   * @brief Set the second contact frame placement with respect to the parent joint
+   * @brief Set the second contact frame placement with respect to the parent
+   * joint
    */
   void set_joint2_placement(const SE3 &joint2_placement);
 
@@ -327,7 +334,8 @@ struct ContactData6DLoopTpl : public ContactDataAbstractTpl<_Scalar> {
   // Placement related data
   SE3 oMf1;   // Placement of the first contact frame in the world frame
   SE3 oMf2;   // Placement of the second contact frame in the world frame
-  SE3 f1Mf2;  // Relative placement of the contact frames in the first contact frame
+  SE3 f1Mf2;  // Relative placement of the contact frames in the first contact
+              // frame
   SE3ActionMatrix j1Xf1;
   SE3ActionMatrix j2Xf2;
   SE3ActionMatrix f1Xf2;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -97,6 +97,13 @@ void ContactModel6DLoopTpl<Scalar>::calc(
   d->f1af2 = d->f1Mf2.act(d->f2af2);
   d->a0 =
       (d->f1af1 - d->f1Mf2.act(d->f2af2) + d->f1vf1.cross(d->f1vf2)).toVector();
+
+  if (gains_[0] != 0.) {
+    d->a0 += gains_[0] * (-pinocchio::log6(d->f1Mf2).toVector());
+  }
+  if (gains_[1] != 0.) {
+    d->a0 += gains_[1] * (d->f1vf1 - d->f1vf2).toVector();
+  }
 }
 
 template <typename Scalar>
@@ -104,9 +111,6 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
     const boost::shared_ptr<ContactDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
-  if (gains_[0] != 0. || gains_[1] != 0.) {
-    throw_pretty("Baumgarte stabilization is not implemented yet");
-  }
   const std::size_t nv = state_->get_nv();
 
   if (joint1_id_ > 0) {
@@ -151,6 +155,24 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
           (joint2_placement_.toActionMatrixInverse() * d->a2_partial_dv) -
       d->f1vf2.toActionMatrix() * d->f1Jf1 +
       d->f1vf1.toActionMatrix() * d->f1Xf2 * d->f2Jf2;
+  if (gains_[0] != 0.) {
+    Matrix6s f1Mf2_log6;
+    pinocchio::Jlog6(d->f1Mf2, f1Mf2_log6);
+    d->da0_dx.leftCols(nv) +=
+        gains_[0] * (-f1Mf2_log6 * (-d->oMf2.toActionMatrixInverse() *
+                                        d->oMf1.toActionMatrix() * d->f1Jf1 +
+                                    d->f2Jf2));
+  }
+  if (gains_[1] != 0.) {
+    d->da0_dx.leftCols(nv) +=
+        gains_[1] *
+        (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq -
+         d->f1Mf2.act(d->f2vf2).toActionMatrix() *
+             (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) -
+         d->f1Xf2 * joint2_placement_.toActionMatrixInverse() *
+             d->v2_partial_dq);
+    d->da0_dx.rightCols(nv) += gains_[1] * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2);
+  }
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -57,6 +57,11 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
                  "for 6D loop contacts"
               << std::endl;
   }
+  if (joint1_id == 0 || joint2_id == 0) {
+    std::cerr << "Warning: At least one of the parents joints id is zero"
+              "you should use crocoddyl::ContactModel6D instead"
+              << std::endl;
+  }
 }
 
 template <typename Scalar>
@@ -193,10 +198,9 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
 
   SE3 j2Mj1 =
       joint2_placement_.act(d->f1Mf2.actInv(joint1_placement_.inverse()));
-
-  d->dtau_dq.noalias() =
-      d->j2Jj2.transpose() *
-      (-f_cross * (d->j2Jj2 - j2Mj1.toActionMatrix() * d->j1Jj1));
+  d->j2Jj1.noalias() = j2Mj1.toActionMatrix() * d->j1Jj1;
+  d->dtau_dq_tmp.noalias() = -f_cross * (d->j2Jj2 - d->j2Jj1);
+  d->dtau_dq.noalias() = d->j2Jj2.transpose() * d->dtau_dq_tmp;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -1,0 +1,239 @@
+
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/contacts/contact-6d.hpp"
+
+namespace crocoddyl {
+
+template <typename Scalar>
+ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
+    boost::shared_ptr<StateMultibody> state, const int joint1_id,
+    const SE3 &joint1_placement, const int joint2_id,
+    const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
+    const std::size_t nu, const Vector2s &gains)
+    : Base(state, pinocchio::ReferenceFrame::LOCAL, 6, nu),
+      gains_(gains),
+      joint1_id_(joint1_id),
+      joint2_id_(joint2_id),
+      joint1_placement_(joint1_placement),
+      joint2_placement_(joint2_placement){
+  if (ref != pinocchio::ReferenceFrame::LOCAL) {
+    std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
+                 "contacts\n";
+  }
+}
+
+template <typename Scalar>
+ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
+    boost::shared_ptr<StateMultibody> state, const int joint1_id,
+    const SE3 &joint1_placement, const int joint2_id,
+    const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
+    const Vector2s &gains)
+    : Base(state, pinocchio::ReferenceFrame::LOCAL, 6),
+      gains_(gains),
+      joint1_id_(joint1_id),
+      joint2_id_(joint2_id),
+      joint1_placement_(joint1_placement),
+      joint2_placement_(joint2_placement){
+  if (ref != pinocchio::ReferenceFrame::LOCAL) {
+    std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
+                 "contacts\n";
+  }
+}
+
+template <typename Scalar>
+ContactModel6DLoopTpl<Scalar>::~ContactModel6DLoopTpl() {}
+
+template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::calc(
+    const boost::shared_ptr<ContactDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &) {
+  Data *d = static_cast<Data *>(data.get());
+  pinocchio::updateFramePlacements<Scalar>(*state_->get_pinocchio().get(),
+                                           *d->pinocchio);
+  d->j1Xf1 = joint1_placement_.toActionMatrix();
+  d->j2Xf2 = joint2_placement_.toActionMatrix();
+
+  pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
+                              joint1_id_, pinocchio::LOCAL, d->j1Jj1);
+  pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
+                              joint2_id_, pinocchio::LOCAL, d->j2Jj2);
+  d->f1Jf1 = d->j1Xf1.inverse() * d->j1Jj1;
+  d->f2Jf2 = d->j2Xf2.inverse() * d->j2Jj2;
+
+  d->oMf1 = d->pinocchio->oMi[joint1_id_].act(joint1_placement_);
+  d->oMf2 = d->pinocchio->oMi[joint2_id_].act(joint2_placement_);
+  d->f1Mf2 = d->oMf1.actInv(d->oMf2);
+  d->f1Xf2 = d->f1Mf2.toActionMatrix();
+
+  d->Jc = d->f1Jf1 - d->f1Xf2 * d->f2Jf2;
+  // Compute the acceleration drift
+  if (joint1_id_ > 0) {
+    d->f1vf1 = joint1_placement_.actInv(d->pinocchio->v[joint1_id_]);
+    d->f1af1 = joint1_placement_.actInv(d->pinocchio->a[joint1_id_]);
+  } else {
+    d->f1vf1.setZero();
+    d->f1af1.setZero();
+  }
+  if (joint2_id_ > 0) {
+    d->f2vf2 = joint2_placement_.actInv(d->pinocchio->v[joint2_id_]);
+    d->f2af2 = joint2_placement_.actInv(d->pinocchio->a[joint2_id_]);
+  } else {
+    d->f2vf2.setZero();
+    d->f2af2.setZero();
+  }
+  d->f1vf2 = d->f1Mf2.act(d->f2vf2);
+  d->f1af2 = d->f1Mf2.act(d->f2af2);
+  d->a0 =
+      (d->f1af1 - d->f1Mf2.act(d->f2af2) + d->f1vf1.cross(d->f1vf2)).toVector();
+}
+
+template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::calcDiff(
+    const boost::shared_ptr<ContactDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &) {
+  Data *d = static_cast<Data *>(data.get());
+  if (gains_[0] != 0. || gains_[1] != 0.) {
+    throw_pretty("Baumgarte stabilization is not implemented yet");
+  }
+  const std::size_t nv = state_->get_nv();
+
+  if (joint1_id_ > 0) {
+    d->f1af1 = joint1_placement_.actInv(d->pinocchio->a[joint1_id_]);
+  } else {
+    d->f1af1.setZero();
+  }
+  if (joint2_id_ > 0) {
+    d->f2af2 = joint2_placement_.actInv(d->pinocchio->a[joint2_id_]);
+  } else {
+    d->f2af2.setZero();
+  }
+  d->f1af2 = d->f1Mf2.act(d->f2af2);
+
+  pinocchio::getJointAccelerationDerivatives(
+      *state_->get_pinocchio().get(), *d->pinocchio, joint1_id_,
+      pinocchio::LOCAL, d->v1_partial_dq, d->a1_partial_dq, d->a1_partial_dv,
+      d->a1_partial_da);
+  pinocchio::getJointAccelerationDerivatives(
+      *state_->get_pinocchio().get(), *d->pinocchio, joint2_id_,
+      pinocchio::LOCAL, d->v2_partial_dq, d->a2_partial_dq, d->a2_partial_dv,
+      d->a2_partial_da);
+
+  d->da0_dq_t1 =
+      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;  //
+  d->da0_dq_t2 = (d->f1af2.toActionMatrix() * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) +
+                  d->f1Xf2 * (joint2_placement_.toActionMatrixInverse() *
+                              d->a2_partial_dq));  //
+  d->da0_dq_t3 =
+      -d->f1vf2.toActionMatrix() * (joint1_placement_.toActionMatrixInverse() *
+                                    d->v1_partial_dq)  // part 1
+      + d->f1vf1.toActionMatrix() * d->f1vf2.toActionMatrix() *
+            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2)  // part 2
+      + d->f1vf1.toActionMatrix() * d->f1Xf2 *
+            (joint2_placement_.toActionMatrixInverse() *
+             d->v2_partial_dq);  // part 3
+
+  d->da0_dx.leftCols(nv) = d->da0_dq_t1 - d->da0_dq_t2 + d->da0_dq_t3;
+  d->da0_dx.rightCols(nv) =
+      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dv -
+      d->f1Xf2 *
+          (joint2_placement_.toActionMatrixInverse() * d->a2_partial_dv) -
+      d->f1vf2.toActionMatrix() * d->f1Jf1 +
+      d->f1vf1.toActionMatrix() * d->f1Xf2 * d->f2Jf2;
+}
+
+template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::updateForce(
+    const boost::shared_ptr<ContactDataAbstract> &data, const VectorXs &force) {
+  if (force.size() != 6) {
+    throw_pretty(
+        "Invalid argument: " << "lambda has wrong dimension (it should be 6)");
+  }
+  Data *d = static_cast<Data *>(data.get());
+  d->f = pinocchio::ForceTpl<Scalar>(-force);
+  switch (type_) {
+    case pinocchio::ReferenceFrame::LOCAL: {
+      data->fext = joint1_placement_.act(data->f);
+      d->joint1_f = -joint1_placement_.act(data->f);
+      d->joint2_f = (joint2_placement_ * d->f1Mf2.inverse()).act(data->f);
+
+      data->dtau_dq.setZero();
+
+      d->f_cross.setZero();
+      d->f_cross.topRightCorner(3, 3) = pinocchio::skew(d->joint2_f.linear());
+      d->f_cross.bottomLeftCorner(3, 3) = pinocchio::skew(d->joint2_f.linear());
+      d->f_cross.bottomRightCorner(3, 3) =
+          pinocchio::skew(d->joint2_f.angular());
+
+      SE3 j2Mj1 =
+          joint2_placement_.act(d->f1Mf2.actInv(joint1_placement_.inverse()));
+
+      data->dtau_dq =
+          d->j2Jj2.transpose() *
+          (-d->f_cross * (d->j2Jj2 - j2Mj1.toActionMatrix() * d->j1Jj1));
+      break;
+    }
+    case pinocchio::ReferenceFrame::WORLD:
+      throw_pretty("Reference frame WORLD is not implemented yet");
+      break;
+    case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
+      throw_pretty(
+          "Reference frame LOCAL_WORLD_ALIGNED is not implemented yet");
+      break;
+  }
+}
+
+template <typename Scalar>
+boost::shared_ptr<ContactDataAbstractTpl<Scalar>>
+ContactModel6DLoopTpl<Scalar>::createData(
+    pinocchio::DataTpl<Scalar> *const data) {
+  return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
+                                      data);
+}
+
+template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::print(std::ostream &os) const {
+  os << "ContactModel6D {frame=" << state_->get_pinocchio()->frames[id_].name
+     << ", type=" << type_ << "}";
+}
+
+template <typename Scalar>
+const int ContactModel6DLoopTpl<Scalar>::get_joint1_id() const {
+  return joint1_id_;
+}
+
+template <typename Scalar>
+const int ContactModel6DLoopTpl<Scalar>::get_joint2_id() const {
+  return joint2_id_;
+}
+
+template <typename Scalar>
+const typename pinocchio::SE3Tpl<Scalar> &
+ContactModel6DLoopTpl<Scalar>::get_joint1_placement() const {
+  return joint1_placement_;
+}
+
+template <typename Scalar>
+const typename pinocchio::SE3Tpl<Scalar> &
+ContactModel6DLoopTpl<Scalar>::get_joint2_placement() const {
+  return joint2_placement_;
+}
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::Vector2s &
+ContactModel6DLoopTpl<Scalar>::get_gains() const {
+  return gains_;
+}
+
+}  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -30,12 +30,12 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       gains_(gains) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
-              "for 6D loop contacts"
+                 "for 6D loop contacts"
               << std::endl;
   }
   if (joint1_id == 0 || joint2_id == 0) {
     std::cerr << "Warning: At least one of the parents joints id is zero"
-              "you should use crocoddyl::ContactModel6D instead"
+                 "you should use crocoddyl::ContactModel6D instead"
               << std::endl;
   }
 }
@@ -59,7 +59,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
   }
   if (joint1_id == 0 || joint2_id == 0) {
     std::cerr << "Warning: At least one of the parents joints id is zero"
-              "you should use crocoddyl::ContactModel6D instead"
+                 "you should use crocoddyl::ContactModel6D instead"
               << std::endl;
   }
 }
@@ -101,8 +101,7 @@ void ContactModel6DLoopTpl<Scalar>::calc(
     d->f1vf2 = d->f1Mf2.act(d->f2vf2);
     d->f1af2 = d->f1Mf2.act(d->f2af2);
   }
-  d->a0.noalias() =
-      (d->f1af1 - d->f1af2 + d->f1vf1.cross(d->f1vf2)).toVector();
+  d->a0.noalias() = (d->f1af1 - d->f1af2 + d->f1vf1.cross(d->f1vf2)).toVector();
 
   if (std::abs<Scalar>(gains_[0]) > std::numeric_limits<Scalar>::epsilon()) {
     d->a0.noalias() -= gains_[0] * pinocchio::log6(d->f1Mf2).toVector();
@@ -135,24 +134,30 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
       pinocchio::LOCAL, d->v2_partial_dq, d->a2_partial_dq, d->a2_partial_dv,
       d->a2_partial_da);
 
-  d->da0_dq_t1.noalias() = joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;
+  d->da0_dq_t1.noalias() =
+      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;
 
   d->da0_dq_t2.noalias() = d->f1af2.toActionMatrix() * d->Jc;
-  d->f2_a2_partial_dq.noalias() = joint2_placement_.toActionMatrixInverse() *
-                              d->a2_partial_dq;
+  d->f2_a2_partial_dq.noalias() =
+      joint2_placement_.toActionMatrixInverse() * d->a2_partial_dq;
   d->da0_dq_t2.noalias() += d->f1Xf2 * d->f2_a2_partial_dq;
-  
-  d->f1_v1_partial_dq.noalias() = joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq;
-  d->da0_dq_t3.noalias() = - d->f1vf2.toActionMatrix() * d->f1_v1_partial_dq;
+
+  d->f1_v1_partial_dq.noalias() =
+      joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq;
+  d->da0_dq_t3.noalias() = -d->f1vf2.toActionMatrix() * d->f1_v1_partial_dq;
   d->da0_dq_t3_tmp.noalias() = d->f1vf2.toActionMatrix() * d->Jc;
   d->da0_dq_t3.noalias() += d->f1vf1.toActionMatrix() * d->da0_dq_t3_tmp;
-  d->da0_dq_t3_tmp.noalias() = joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq;
-  d->da0_dq_t3.noalias() += d->f1vf1.toActionMatrix() * d->f1Xf2 * d->da0_dq_t3_tmp;
+  d->da0_dq_t3_tmp.noalias() =
+      joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq;
+  d->da0_dq_t3.noalias() +=
+      d->f1vf1.toActionMatrix() * d->f1Xf2 * d->da0_dq_t3_tmp;
   d->da0_dx.leftCols(nv).noalias() = d->da0_dq_t1 - d->da0_dq_t2 + d->da0_dq_t3;
 
-  d->f2_a2_partial_dv.noalias() = joint2_placement_.toActionMatrixInverse() * d->a2_partial_dv;
+  d->f2_a2_partial_dv.noalias() =
+      joint2_placement_.toActionMatrixInverse() * d->a2_partial_dv;
   d->f1Jf2.noalias() = d->f1Xf2 * d->f2Jf2;
-  d->da0_dx.rightCols(nv).noalias() = joint1_placement_.toActionMatrixInverse() * d->a1_partial_dv;
+  d->da0_dx.rightCols(nv).noalias() =
+      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dv;
   d->da0_dx.rightCols(nv).noalias() -= d->f1Xf2 * d->f2_a2_partial_dv;
   d->da0_dx.rightCols(nv).noalias() -= d->f1vf2.toActionMatrix() * d->f1Jf1;
   d->da0_dx.rightCols(nv).noalias() += d->f1vf1.toActionMatrix() * d->f1Jf2;
@@ -160,12 +165,14 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
   if (std::abs<Scalar>(gains_[0]) > std::numeric_limits<Scalar>::epsilon()) {
     Matrix6s f1Mf2_log6;
     pinocchio::Jlog6(d->f1Mf2, f1Mf2_log6);
-    d->dpos_dq.noalias() = d->oMf2.toActionMatrixInverse() * d->oMf1.toActionMatrix() * d->f1Jf1;
+    d->dpos_dq.noalias() =
+        d->oMf2.toActionMatrixInverse() * d->oMf1.toActionMatrix() * d->f1Jf1;
     d->dpos_dq.noalias() -= d->f2Jf2;
     d->da0_dx.leftCols(nv).noalias() += gains_[0] * f1Mf2_log6 * d->dpos_dq;
   }
   if (std::abs<Scalar>(gains_[1]) > std::numeric_limits<Scalar>::epsilon()) {
-    d->f2_v2_partial_dq.noalias() = joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq;
+    d->f2_v2_partial_dq.noalias() =
+        joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq;
     d->f1_v2_partial_dq.noalias() = d->f1Xf2 * d->f2_v2_partial_dq;
     d->dvel_dq.noalias() = d->f1_v1_partial_dq;
     d->dvel_dq.noalias() -= d->f1vf2.toActionMatrix() * d->Jc;
@@ -179,8 +186,8 @@ template <typename Scalar>
 void ContactModel6DLoopTpl<Scalar>::updateForce(
     const boost::shared_ptr<ContactDataAbstract> &data, const VectorXs &force) {
   if (force.size() != 6) {
-    throw_pretty(
-        "Contact force vector has wrong dimension (expected 6 got " << force.size() << ")");
+    throw_pretty("Contact force vector has wrong dimension (expected 6 got "
+                 << force.size() << ")");
   }
   Data *d = static_cast<Data *>(data.get());
   d->f = pinocchio::ForceTpl<Scalar>(-force);
@@ -205,8 +212,8 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
 
 template <typename Scalar>
 void ContactModel6DLoopTpl<Scalar>::updateForceDiff(
-    const boost::shared_ptr<ContactDataAbstract>& data, const MatrixXs& df_dx,
-    const MatrixXs& df_du) {
+    const boost::shared_ptr<ContactDataAbstract> &data, const MatrixXs &df_dx,
+    const MatrixXs &df_du) {
   if (static_cast<std::size_t>(df_dx.rows()) != nc_ ||
       static_cast<std::size_t>(df_dx.cols()) != state_->get_ndx())
     throw_pretty("df_dx has wrong dimension");

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -29,8 +29,9 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint2_placement_(joint2_placement),
       gains_(gains) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
-    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported for 6D loop "
-                "contacts\n"
+    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
+                 "for 6D loop "
+                 "contacts\n"
               << std::endl;
   }
 }
@@ -45,11 +46,12 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
-      joint2_placement_(joint2_placement), 
+      joint2_placement_(joint2_placement),
       gains_(gains) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
-    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported for 6D loop "
-                "contacts\n"
+    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
+                 "for 6D loop "
+                 "contacts\n"
               << std::endl;
   }
 }
@@ -126,19 +128,17 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
       pinocchio::LOCAL, d->v2_partial_dq, d->a2_partial_dq, d->a2_partial_dv,
       d->a2_partial_da);
 
-  d->da0_dq_t1 =
-      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;  
+  d->da0_dq_t1 = joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;
   d->da0_dq_t2 = (d->f1af2.toActionMatrix() * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) +
                   d->f1Xf2 * (joint2_placement_.toActionMatrixInverse() *
-                              d->a2_partial_dq));  
+                              d->a2_partial_dq));
   d->da0_dq_t3 =
-      -d->f1vf2.toActionMatrix() * (joint1_placement_.toActionMatrixInverse() *
-                                    d->v1_partial_dq)  
-      + d->f1vf1.toActionMatrix() * d->f1vf2.toActionMatrix() *
-            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2)  
-      + d->f1vf1.toActionMatrix() * d->f1Xf2 *
-            (joint2_placement_.toActionMatrixInverse() *
-            d->v2_partial_dq);  
+      -d->f1vf2.toActionMatrix() *
+          (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq) +
+      d->f1vf1.toActionMatrix() * d->f1vf2.toActionMatrix() *
+          (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) +
+      d->f1vf1.toActionMatrix() * d->f1Xf2 *
+          (joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq);
 
   d->da0_dx.leftCols(nv).noalias() = d->da0_dq_t1 - d->da0_dq_t2 + d->da0_dq_t3;
   d->da0_dx.rightCols(nv) =
@@ -151,20 +151,20 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
     Matrix6s f1Mf2_log6;
     pinocchio::Jlog6(d->f1Mf2, f1Mf2_log6);
     d->da0_dx.leftCols(nv).noalias() +=
-      gains_[0] * f1Mf2_log6 * (d->oMf2.toActionMatrixInverse() *
-                                  d->oMf1.toActionMatrix() * d->f1Jf1 -
-                                  d->f2Jf2);
+        gains_[0] * f1Mf2_log6 *
+        (d->oMf2.toActionMatrixInverse() * d->oMf1.toActionMatrix() * d->f1Jf1 -
+         d->f2Jf2);
   }
   if (std::abs<Scalar>(gains_[1]) > std::numeric_limits<Scalar>::epsilon()) {
     d->da0_dx.leftCols(nv).noalias() +=
-      gains_[1] *
-      (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq -
-        d->f1Mf2.act(d->f2vf2).toActionMatrix() *
-            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) -
-        d->f1Xf2 * joint2_placement_.toActionMatrixInverse() *
-            d->v2_partial_dq);
-    d->da0_dx.rightCols(nv).noalias() += 
-      gains_[1] * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2);
+        gains_[1] *
+        (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq -
+         d->f1Mf2.act(d->f2vf2).toActionMatrix() *
+             (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) -
+         d->f1Xf2 * joint2_placement_.toActionMatrixInverse() *
+             d->v2_partial_dq);
+    d->da0_dx.rightCols(nv).noalias() +=
+        gains_[1] * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2);
   }
 }
 
@@ -184,9 +184,12 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
       d->joint2_f = (joint2_placement_ * d->f1Mf2.inverse()).act(d->f);
 
       Matrix6s f_cross = Matrix6s::Zero(6, 6);
-      f_cross.template topRightCorner<3, 3>() = pinocchio::skew(d->joint2_f.linear());
-      f_cross.template bottomLeftCorner<3, 3>() = pinocchio::skew(d->joint2_f.linear());
-      f_cross.template bottomRightCorner<3, 3>() = pinocchio::skew(d->joint2_f.angular());
+      f_cross.template topRightCorner<3, 3>() =
+          pinocchio::skew(d->joint2_f.linear());
+      f_cross.template bottomLeftCorner<3, 3>() =
+          pinocchio::skew(d->joint2_f.linear());
+      f_cross.template bottomRightCorner<3, 3>() =
+          pinocchio::skew(d->joint2_f.angular());
 
       SE3 j2Mj1 =
           joint2_placement_.act(d->f1Mf2.actInv(joint1_placement_.inverse()));
@@ -197,11 +200,14 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
       break;
     }
     case pinocchio::ReferenceFrame::WORLD:
-      throw_pretty("Reference frame pinocchio::WORLD is not implemented, please use pinocchio::LOCAL");
+      throw_pretty(
+          "Reference frame pinocchio::WORLD is not implemented, please use "
+          "pinocchio::LOCAL");
       break;
     case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
       throw_pretty(
-          "Reference frame pinocchio::LOCAL_WORLD_ALIGNED is not implemented, please use pinocchio::LOCAL");
+          "Reference frame pinocchio::LOCAL_WORLD_ALIGNED is not implemented, "
+          "please use pinocchio::LOCAL");
       break;
   }
 }

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -20,7 +20,7 @@ template <typename Scalar>
 ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
-    const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
+    const SE3 &joint2_placement, const pinocchio::ReferenceFrame type
     const std::size_t nu, const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6, nu),
       joint1_id_(joint1_id),
@@ -28,7 +28,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint1_placement_(joint1_placement),
       joint2_placement_(joint2_placement),
       gains_(gains) {
-  if (ref != pinocchio::ReferenceFrame::LOCAL) {
+  if (type!= pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
                  "for 6D loop contacts"
               << std::endl;
@@ -44,7 +44,7 @@ template <typename Scalar>
 ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
-    const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
+    const SE3 &joint2_placement, const pinocchio::ReferenceFrame type
     const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6),
       joint1_id_(joint1_id),
@@ -52,7 +52,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint1_placement_(joint1_placement),
       joint2_placement_(joint2_placement),
       gains_(gains) {
-  if (ref != pinocchio::ReferenceFrame::LOCAL) {
+  if (type!= pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
                  "for 6D loop contacts"
               << std::endl;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -128,11 +128,11 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
   pinocchio::getJointAccelerationDerivatives(
       *state_->get_pinocchio().get(), *d->pinocchio, joint1_id_,
       pinocchio::LOCAL, d->v1_partial_dq, d->a1_partial_dq, d->a1_partial_dv,
-      d->a1_partial_da);
+      d->__partial_da);
   pinocchio::getJointAccelerationDerivatives(
       *state_->get_pinocchio().get(), *d->pinocchio, joint2_id_,
       pinocchio::LOCAL, d->v2_partial_dq, d->a2_partial_dq, d->a2_partial_dv,
-      d->a2_partial_da);
+      d->__partial_da);
 
   d->da0_dq_t1.noalias() =
       joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -23,14 +23,15 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
     const std::size_t nu, const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6, nu),
-      gains_(gains),
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
-      joint2_placement_(joint2_placement) {
+      joint2_placement_(joint2_placement),
+      gains_(gains) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
-    std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
-                 "contacts\n";
+    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported for 6D loop "
+                "contacts\n"
+              << std::endl;
   }
 }
 
@@ -41,14 +42,15 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     const SE3 &joint2_placement, const pinocchio::ReferenceFrame ref,
     const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6),
-      gains_(gains),
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
-      joint2_placement_(joint2_placement) {
+      joint2_placement_(joint2_placement), 
+      gains_(gains) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
-    std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
-                 "contacts\n";
+    std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported for 6D loop "
+                "contacts\n"
+              << std::endl;
   }
 }
 
@@ -62,46 +64,40 @@ void ContactModel6DLoopTpl<Scalar>::calc(
   Data *d = static_cast<Data *>(data.get());
   pinocchio::updateFramePlacements<Scalar>(*state_->get_pinocchio().get(),
                                            *d->pinocchio);
-  d->j1Xf1 = joint1_placement_.toActionMatrix();
-  d->j2Xf2 = joint2_placement_.toActionMatrix();
+  d->j1Xf1.noalias() = joint1_placement_.toActionMatrix();
+  d->j2Xf2.noalias() = joint2_placement_.toActionMatrix();
 
   pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
                               joint1_id_, pinocchio::LOCAL, d->j1Jj1);
   pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
                               joint2_id_, pinocchio::LOCAL, d->j2Jj2);
-  d->f1Jf1 = d->j1Xf1.inverse() * d->j1Jj1;
-  d->f2Jf2 = d->j2Xf2.inverse() * d->j2Jj2;
+  d->f1Jf1.noalias() = d->j1Xf1.inverse() * d->j1Jj1;
+  d->f2Jf2.noalias() = d->j2Xf2.inverse() * d->j2Jj2;
 
   d->oMf1 = d->pinocchio->oMi[joint1_id_].act(joint1_placement_);
   d->oMf2 = d->pinocchio->oMi[joint2_id_].act(joint2_placement_);
   d->f1Mf2 = d->oMf1.actInv(d->oMf2);
-  d->f1Xf2 = d->f1Mf2.toActionMatrix();
+  d->f1Xf2.noalias() = d->f1Mf2.toActionMatrix();
 
-  d->Jc = d->f1Jf1 - d->f1Xf2 * d->f2Jf2;
+  d->Jc.noalias() = d->f1Jf1 - d->f1Xf2 * d->f2Jf2;
   // Compute the acceleration drift
   if (joint1_id_ > 0) {
     d->f1vf1 = joint1_placement_.actInv(d->pinocchio->v[joint1_id_]);
     d->f1af1 = joint1_placement_.actInv(d->pinocchio->a[joint1_id_]);
-  } else {
-    d->f1vf1.setZero();
-    d->f1af1.setZero();
   }
   if (joint2_id_ > 0) {
     d->f2vf2 = joint2_placement_.actInv(d->pinocchio->v[joint2_id_]);
     d->f2af2 = joint2_placement_.actInv(d->pinocchio->a[joint2_id_]);
-  } else {
-    d->f2vf2.setZero();
-    d->f2af2.setZero();
+    d->f1vf2 = d->f1Mf2.act(d->f2vf2);
+    d->f1af2 = d->f1Mf2.act(d->f2af2);
   }
-  d->f1vf2 = d->f1Mf2.act(d->f2vf2);
-  d->f1af2 = d->f1Mf2.act(d->f2af2);
-  d->a0 =
+  d->a0.noalias() =
       (d->f1af1 - d->f1Mf2.act(d->f2af2) + d->f1vf1.cross(d->f1vf2)).toVector();
 
-  if (gains_[0] != 0.) {
-    d->a0 += gains_[0] * (-pinocchio::log6(d->f1Mf2).toVector());
+  if (std::abs<Scalar>(gains_[0]) > std::numeric_limits<Scalar>::epsilon()) {
+    d->a0.noalias() -= gains_[0] * pinocchio::log6(d->f1Mf2).toVector();
   }
-  if (gains_[1] != 0.) {
+  if (std::abs<Scalar>(gains_[1]) > std::numeric_limits<Scalar>::epsilon()) {
     d->a0 += gains_[1] * (d->f1vf1 - d->f1vf2).toVector();
   }
 }
@@ -115,15 +111,11 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
 
   if (joint1_id_ > 0) {
     d->f1af1 = joint1_placement_.actInv(d->pinocchio->a[joint1_id_]);
-  } else {
-    d->f1af1.setZero();
   }
   if (joint2_id_ > 0) {
     d->f2af2 = joint2_placement_.actInv(d->pinocchio->a[joint2_id_]);
-  } else {
-    d->f2af2.setZero();
+    d->f1af2 = d->f1Mf2.act(d->f2af2);
   }
-  d->f1af2 = d->f1Mf2.act(d->f2af2);
 
   pinocchio::getJointAccelerationDerivatives(
       *state_->get_pinocchio().get(), *d->pinocchio, joint1_id_,
@@ -135,43 +127,44 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
       d->a2_partial_da);
 
   d->da0_dq_t1 =
-      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;  //
+      joint1_placement_.toActionMatrixInverse() * d->a1_partial_dq;  
   d->da0_dq_t2 = (d->f1af2.toActionMatrix() * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) +
                   d->f1Xf2 * (joint2_placement_.toActionMatrixInverse() *
-                              d->a2_partial_dq));  //
+                              d->a2_partial_dq));  
   d->da0_dq_t3 =
       -d->f1vf2.toActionMatrix() * (joint1_placement_.toActionMatrixInverse() *
-                                    d->v1_partial_dq)  // part 1
+                                    d->v1_partial_dq)  
       + d->f1vf1.toActionMatrix() * d->f1vf2.toActionMatrix() *
-            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2)  // part 2
+            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2)  
       + d->f1vf1.toActionMatrix() * d->f1Xf2 *
             (joint2_placement_.toActionMatrixInverse() *
-             d->v2_partial_dq);  // part 3
+            d->v2_partial_dq);  
 
-  d->da0_dx.leftCols(nv) = d->da0_dq_t1 - d->da0_dq_t2 + d->da0_dq_t3;
+  d->da0_dx.leftCols(nv).noalias() = d->da0_dq_t1 - d->da0_dq_t2 + d->da0_dq_t3;
   d->da0_dx.rightCols(nv) =
       joint1_placement_.toActionMatrixInverse() * d->a1_partial_dv -
       d->f1Xf2 *
           (joint2_placement_.toActionMatrixInverse() * d->a2_partial_dv) -
       d->f1vf2.toActionMatrix() * d->f1Jf1 +
       d->f1vf1.toActionMatrix() * d->f1Xf2 * d->f2Jf2;
-  if (gains_[0] != 0.) {
+  if (std::abs<Scalar>(gains_[0]) > std::numeric_limits<Scalar>::epsilon()) {
     Matrix6s f1Mf2_log6;
     pinocchio::Jlog6(d->f1Mf2, f1Mf2_log6);
-    d->da0_dx.leftCols(nv) +=
-        gains_[0] * (-f1Mf2_log6 * (-d->oMf2.toActionMatrixInverse() *
-                                        d->oMf1.toActionMatrix() * d->f1Jf1 +
-                                    d->f2Jf2));
+    d->da0_dx.leftCols(nv).noalias() +=
+      gains_[0] * f1Mf2_log6 * (d->oMf2.toActionMatrixInverse() *
+                                  d->oMf1.toActionMatrix() * d->f1Jf1 -
+                                  d->f2Jf2);
   }
-  if (gains_[1] != 0.) {
-    d->da0_dx.leftCols(nv) +=
-        gains_[1] *
-        (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq -
-         d->f1Mf2.act(d->f2vf2).toActionMatrix() *
-             (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) -
-         d->f1Xf2 * joint2_placement_.toActionMatrixInverse() *
-             d->v2_partial_dq);
-    d->da0_dx.rightCols(nv) += gains_[1] * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2);
+  if (std::abs<Scalar>(gains_[1]) > std::numeric_limits<Scalar>::epsilon()) {
+    d->da0_dx.leftCols(nv).noalias() +=
+      gains_[1] *
+      (joint1_placement_.toActionMatrixInverse() * d->v1_partial_dq -
+        d->f1Mf2.act(d->f2vf2).toActionMatrix() *
+            (d->f1Jf1 - d->f1Xf2 * d->f2Jf2) -
+        d->f1Xf2 * joint2_placement_.toActionMatrixInverse() *
+            d->v2_partial_dq);
+    d->da0_dx.rightCols(nv).noalias() += 
+      gains_[1] * (d->f1Jf1 - d->f1Xf2 * d->f2Jf2);
   }
 }
 
@@ -186,32 +179,29 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
   d->f = pinocchio::ForceTpl<Scalar>(-force);
   switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL: {
-      data->fext = joint1_placement_.act(data->f);
-      d->joint1_f = -joint1_placement_.act(data->f);
-      d->joint2_f = (joint2_placement_ * d->f1Mf2.inverse()).act(data->f);
+      d->fext = joint1_placement_.act(d->f);
+      d->joint1_f = -joint1_placement_.act(d->f);
+      d->joint2_f = (joint2_placement_ * d->f1Mf2.inverse()).act(d->f);
 
-      data->dtau_dq.setZero();
-
-      d->f_cross.setZero();
-      d->f_cross.topRightCorner(3, 3) = pinocchio::skew(d->joint2_f.linear());
-      d->f_cross.bottomLeftCorner(3, 3) = pinocchio::skew(d->joint2_f.linear());
-      d->f_cross.bottomRightCorner(3, 3) =
-          pinocchio::skew(d->joint2_f.angular());
+      Matrix6s f_cross = Matrix6s::Zero(6, 6);
+      f_cross.template topRightCorner<3, 3>() = pinocchio::skew(d->joint2_f.linear());
+      f_cross.template bottomLeftCorner<3, 3>() = pinocchio::skew(d->joint2_f.linear());
+      f_cross.template bottomRightCorner<3, 3>() = pinocchio::skew(d->joint2_f.angular());
 
       SE3 j2Mj1 =
           joint2_placement_.act(d->f1Mf2.actInv(joint1_placement_.inverse()));
 
-      data->dtau_dq =
+      d->dtau_dq.noalias() =
           d->j2Jj2.transpose() *
-          (-d->f_cross * (d->j2Jj2 - j2Mj1.toActionMatrix() * d->j1Jj1));
+          (-f_cross * (d->j2Jj2 - j2Mj1.toActionMatrix() * d->j1Jj1));
       break;
     }
     case pinocchio::ReferenceFrame::WORLD:
-      throw_pretty("Reference frame WORLD is not implemented yet");
+      throw_pretty("Reference frame pinocchio::WORLD is not implemented, please use pinocchio::LOCAL");
       break;
     case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
       throw_pretty(
-          "Reference frame LOCAL_WORLD_ALIGNED is not implemented yet");
+          "Reference frame pinocchio::LOCAL_WORLD_ALIGNED is not implemented, please use pinocchio::LOCAL");
       break;
   }
 }

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -200,6 +200,22 @@ void ContactModel6DLoopTpl<Scalar>::updateForce(
 }
 
 template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::updateForceDiff(
+    const boost::shared_ptr<ContactDataAbstract>& data, const MatrixXs& df_dx,
+    const MatrixXs& df_du) {
+  if (static_cast<std::size_t>(df_dx.rows()) != nc_ ||
+      static_cast<std::size_t>(df_dx.cols()) != state_->get_ndx())
+    throw_pretty("df_dx has wrong dimension");
+
+  if (static_cast<std::size_t>(df_du.rows()) != nc_ ||
+      static_cast<std::size_t>(df_du.cols()) != nu_)
+    throw_pretty("df_du has wrong dimension");
+
+  data->df_dx = -df_dx;
+  data->df_du = -df_du;
+}
+
+template <typename Scalar>
 boost::shared_ptr<ContactDataAbstractTpl<Scalar>>
 ContactModel6DLoopTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar> *const data) {

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -128,9 +128,9 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
     ForceDataAbstractTpl<Scalar> &fdata_i = d->force_datas[i];
 
     pinocchio::getJointAccelerationDerivatives(
-        *state_->get_pinocchio().get(), *d->pinocchio, fdata_i.frame, pinocchio::LOCAL,
-        fdata_i.v_partial_dq, fdata_i.a_partial_dq, fdata_i.a_partial_dv,
-        fdata_i.a_partial_da);
+        *state_->get_pinocchio().get(), *d->pinocchio, fdata_i.frame,
+        pinocchio::LOCAL, fdata_i.v_partial_dq, fdata_i.a_partial_dq,
+        fdata_i.a_partial_dv, fdata_i.a_partial_da);
   }
 
   d->da0_dq_t1.noalias() =
@@ -235,7 +235,9 @@ ContactModel6DLoopTpl<Scalar>::createData(
 
 template <typename Scalar>
 void ContactModel6DLoopTpl<Scalar>::print(std::ostream &os) const {
-  os << "ContactModel6D {frame 1 = " << state_->get_pinocchio()->frames[id_[0]].name << ", frame 2 = " << state_->get_pinocchio()->frames[id_[1]].name
+  os << "ContactModel6D {frame 1 = "
+     << state_->get_pinocchio()->frames[id_[0]].name
+     << ", frame 2 = " << state_->get_pinocchio()->frames[id_[1]].name
      << ", type = " << type_ << ", gains = " << gains_.transpose() << "}";
 }
 
@@ -255,6 +257,13 @@ template <typename Scalar>
 void ContactModel6DLoopTpl<Scalar>::set_gains(
     const typename MathBaseTpl<Scalar>::Vector2s &gains) {
   gains_ = gains;
+}
+
+template <typename Scalar>
+void ContactModel6DLoopTpl<Scalar>::set_placement(
+    const int force_index,
+    const typename pinocchio::SE3Tpl<Scalar> &placement) {
+  placements_[force_index] = placement;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -27,7 +27,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
-      joint2_placement_(joint2_placement){
+      joint2_placement_(joint2_placement) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
                  "contacts\n";
@@ -45,7 +45,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
-      joint2_placement_(joint2_placement){
+      joint2_placement_(joint2_placement) {
   if (ref != pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame LOCAL is supported for 6D loop "
                  "contacts\n";

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -20,15 +20,16 @@ template <typename Scalar>
 ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
-    const SE3 &joint2_placement, const pinocchio::ReferenceFrame type
-    const std::size_t nu, const Vector2s &gains)
+    const SE3 &joint2_placement,
+    const pinocchio::ReferenceFrame type const std::size_t nu,
+    const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6, nu),
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
       joint2_placement_(joint2_placement),
       gains_(gains) {
-  if (type!= pinocchio::ReferenceFrame::LOCAL) {
+  if (type != pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
                  "for 6D loop contacts"
               << std::endl;
@@ -44,15 +45,15 @@ template <typename Scalar>
 ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
-    const SE3 &joint2_placement, const pinocchio::ReferenceFrame type
-    const Vector2s &gains)
+    const SE3 &joint2_placement,
+    const pinocchio::ReferenceFrame type const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6),
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),
       joint1_placement_(joint1_placement),
       joint2_placement_(joint2_placement),
       gains_(gains) {
-  if (type!= pinocchio::ReferenceFrame::LOCAL) {
+  if (type != pinocchio::ReferenceFrame::LOCAL) {
     std::cerr << "Warning: Only reference frame pinocchio::LOCAL is supported "
                  "for 6D loop contacts"
               << std::endl;

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -72,17 +72,12 @@ void ContactModel6DLoopTpl<Scalar>::calc(
     const boost::shared_ptr<ContactDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
-  pinocchio::updateFramePlacements<Scalar>(*state_->get_pinocchio().get(),
-                                           *d->pinocchio);
-  d->j1Xf1.noalias() = joint1_placement_.toActionMatrix();
-  d->j2Xf2.noalias() = joint2_placement_.toActionMatrix();
-
   pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
                               joint1_id_, pinocchio::LOCAL, d->j1Jj1);
   pinocchio::getJointJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
                               joint2_id_, pinocchio::LOCAL, d->j2Jj2);
-  d->f1Jf1.noalias() = d->j1Xf1.inverse() * d->j1Jj1;
-  d->f2Jf2.noalias() = d->j2Xf2.inverse() * d->j2Jj2;
+  d->f1Jf1.noalias() = d->f1Xj1 * d->j1Jj1;
+  d->f2Jf2.noalias() = d->f2Xj2 * d->j2Jj2;
 
   d->oMf1 = d->pinocchio->oMi[joint1_id_].act(joint1_placement_);
   d->oMf2 = d->pinocchio->oMi[joint2_id_].act(joint2_placement_);

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -21,7 +21,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
     const SE3 &joint2_placement,
-    const pinocchio::ReferenceFrame type const std::size_t nu,
+    const pinocchio::ReferenceFrame type, const std::size_t nu,
     const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6, nu),
       joint1_id_(joint1_id),
@@ -46,7 +46,7 @@ ContactModel6DLoopTpl<Scalar>::ContactModel6DLoopTpl(
     boost::shared_ptr<StateMultibody> state, const int joint1_id,
     const SE3 &joint1_placement, const int joint2_id,
     const SE3 &joint2_placement,
-    const pinocchio::ReferenceFrame type const Vector2s &gains)
+    const pinocchio::ReferenceFrame type, const Vector2s &gains)
     : Base(state, pinocchio::ReferenceFrame::LOCAL, 6),
       joint1_id_(joint1_id),
       joint2_id_(joint2_id),

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -174,9 +174,8 @@ void ContactModel6DLoopTpl<Scalar>::calcDiff(
     d->f2_v2_partial_dq.noalias() =
         joint2_placement_.toActionMatrixInverse() * d->v2_partial_dq;
     d->f1_v2_partial_dq.noalias() = d->f1Xf2 * d->f2_v2_partial_dq;
-    d->dvel_dq.noalias() = d->f1_v1_partial_dq;
+    d->dvel_dq.noalias() = d->f1_v1_partial_dq - d->f1_v2_partial_dq;
     d->dvel_dq.noalias() -= d->f1vf2.toActionMatrix() * d->Jc;
-    d->dvel_dq.noalias() -= d->f1_v2_partial_dq;
     d->da0_dx.leftCols(nv).noalias() += gains_[1] * d->dvel_dq;
     d->da0_dx.rightCols(nv).noalias() += gains_[1] * d->Jc;
   }

--- a/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-6d-loop.hxx
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -178,7 +178,7 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ContactData6DTpl(Model<Scalar>* const model,
                    pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Base(model, data, 1),
         rMf(SE3::Identity()),
         lwaMl(SE3::Identity()),
         v(Motion::Zero()),
@@ -191,9 +191,12 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
         a_partial_dv(6, model->get_state()->get_nv()),
         a_partial_da(6, model->get_state()->get_nv()),
         fJf_df(6, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     da0_local_dx.setZero();
     fJf.setZero();
     v_partial_dq.setZero();
@@ -212,14 +215,9 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
 
   using Base::a0;
   using Base::da0_dx;
-  using Base::df_du;
-  using Base::df_dx;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
   using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   SE3 rMf;
   SE3 lwaMl;
@@ -227,7 +225,7 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
   Motion a0_local;
   Force f_local;
   Matrix6xs da0_local_dx;
-  MatrixXs fJf;
+  Matrix6xs fJf;
   Matrix6xs v_partial_dq;
   Matrix6xs a_partial_dq;
   Matrix6xs a_partial_dv;

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -185,24 +185,14 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
         a0_local(Motion::Zero()),
         f_local(Force::Zero()),
         da0_local_dx(6, model->get_state()->get_ndx()),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dq(6, model->get_state()->get_nv()),
-        a_partial_dv(6, model->get_state()->get_nv()),
-        a_partial_da(6, model->get_state()->get_nv()),
         fJf_df(6, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
-    fdata.frame = model->get_id();
+    fdata.frame = model->get_id(0);
     fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
     fdata.fXj = fdata.jMf.inverse().toActionMatrix();
 
     da0_local_dx.setZero();
-    fJf.setZero();
-    v_partial_dq.setZero();
-    a_partial_dq.setZero();
-    a_partial_dv.setZero();
-    a_partial_da.setZero();
     av_world_skew.setZero();
     aw_world_skew.setZero();
     av_skew.setZero();
@@ -225,11 +215,6 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
   Motion a0_local;
   Force f_local;
   Matrix6xs da0_local_dx;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs a_partial_dq;
-  Matrix6xs a_partial_dv;
-  Matrix6xs a_partial_da;
   Matrix3s av_world_skew;
   Matrix3s aw_world_skew;
   Matrix3s av_skew;

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -251,10 +251,10 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
-        ContactModel6DLoopTpl<Scalar>* c =
+        const ContactModel6DLoopTpl<Scalar>* c =
             dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
         if (c != nullptr) {
-          ContactData6DLoopTpl<Scalar>* dc =
+          const ContactData6DLoopTpl<Scalar>* dc =
               static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
           const pinocchio::JointIndex joint1 = c->get_joint1_id();
           const pinocchio::JointIndex joint2 = c->get_joint2_id();
@@ -288,10 +288,10 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
-        ContactModel6DLoopTpl<Scalar>* c =
+        const ContactModel6DLoopTpl<Scalar>* c =
             dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
         if (c != nullptr) {
-          ContactData6DLoopTpl<Scalar>* dc =
+          const ContactData6DLoopTpl<Scalar>* dc =
               static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
           const pinocchio::JointIndex joint1 = c->get_joint1_id();
           const pinocchio::JointIndex joint2 = c->get_joint2_id();

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -263,12 +263,12 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         } else {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->frame].parentJoint;
+              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
 #else
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->frame].parent;
+              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
 #endif
-          data->fext[joint] = d_i->fext;
+          data->fext[joint] = d_i->force_datas[0].fext; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
         }
       } else {
         m_i->contact->setZeroForce(d_i);
@@ -300,12 +300,12 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         } else {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->frame].parentJoint;
+              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
 #else
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->frame].parent;
+              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
 #endif
-          data->fext[joint] = d_i->fext;
+          data->fext[joint] = d_i->force_datas[0].fext;  // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
         }
         nc += nc_i;
       } else {

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -7,6 +7,7 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "contact-6d-loop.hpp"
 namespace crocoddyl {
 
 template <typename Scalar>
@@ -250,14 +251,25 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
+        ContactModel6DLoopTpl<Scalar>* c =
+            dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
+        if (c != nullptr) {
+          ContactData6DLoopTpl<Scalar>* dc =
+              static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
+          const pinocchio::JointIndex joint1 = c->get_joint1_id();
+          const pinocchio::JointIndex joint2 = c->get_joint2_id();
+          data->fext[joint1] = dc->joint1_f;
+          data->fext[joint2] = dc->joint2_f;
+        } else {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
-        const pinocchio::JointIndex joint =
-            state_->get_pinocchio()->frames[d_i->frame].parentJoint;
+          const pinocchio::JointIndex joint =
+              state_->get_pinocchio()->frames[d_i->frame].parentJoint;
 #else
-        const pinocchio::JointIndex joint =
-            state_->get_pinocchio()->frames[d_i->frame].parent;
+          const pinocchio::JointIndex joint =
+              state_->get_pinocchio()->frames[d_i->frame].parent;
 #endif
-        data->fext[joint] = d_i->fext;
+          data->fext[joint] = d_i->fext;
+        }
       } else {
         m_i->contact->setZeroForce(d_i);
       }
@@ -276,14 +288,25 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
+        ContactModel6DLoopTpl<Scalar>* c =
+            dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
+        if (c != nullptr) {
+          ContactData6DLoopTpl<Scalar>* dc =
+              static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
+          const pinocchio::JointIndex joint1 = c->get_joint1_id();
+          const pinocchio::JointIndex joint2 = c->get_joint2_id();
+          data->fext[joint1] = dc->joint1_f;
+          data->fext[joint2] = dc->joint2_f;
+        } else {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
-        const pinocchio::JointIndex joint =
-            state_->get_pinocchio()->frames[d_i->frame].parentJoint;
+          const pinocchio::JointIndex joint =
+              state_->get_pinocchio()->frames[d_i->frame].parentJoint;
 #else
-        const pinocchio::JointIndex joint =
-            state_->get_pinocchio()->frames[d_i->frame].parent;
+          const pinocchio::JointIndex joint =
+              state_->get_pinocchio()->frames[d_i->frame].parent;
 #endif
-        data->fext[joint] = d_i->fext;
+          data->fext[joint] = d_i->fext;
+        }
         nc += nc_i;
       } else {
         m_i->contact->setZeroForce(d_i);

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -251,24 +251,19 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
-        const ContactModel6DLoopTpl<Scalar>* c =
-            dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
-        if (c != nullptr) {
-          const ContactData6DLoopTpl<Scalar>* dc =
-              static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
-          const pinocchio::JointIndex joint1 = c->get_joint1_id();
-          const pinocchio::JointIndex joint2 = c->get_joint2_id();
-          data->fext[joint1] = dc->joint1_f;
-          data->fext[joint2] = dc->joint2_f;
-        } else {
+        for (size_t i = 0; i < m_i->contact->get_nf(); ++i) {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+              state_->get_pinocchio()
+                  ->frames[d_i->force_datas[i].frame]
+                  .parentJoint;
 #else
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+              state_->get_pinocchio()
+                  ->frames[d_i->force_datas[i]->frame]
+                  .parent;
 #endif
-          data->fext[joint] = d_i->force_datas[0].fext; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+          data->fext[joint] = d_i->force_datas[i].fext;
         }
       } else {
         m_i->contact->setZeroForce(d_i);
@@ -288,24 +283,19 @@ void ContactModelMultipleTpl<Scalar>::updateForce(
         const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
             force.segment(nc, nc_i);
         m_i->contact->updateForce(d_i, force_i);
-        const ContactModel6DLoopTpl<Scalar>* c =
-            dynamic_cast<ContactModel6DLoopTpl<Scalar>*>(m_i->contact.get());
-        if (c != nullptr) {
-          const ContactData6DLoopTpl<Scalar>* dc =
-              static_cast<ContactData6DLoopTpl<Scalar>*>(d_i.get());
-          const pinocchio::JointIndex joint1 = c->get_joint1_id();
-          const pinocchio::JointIndex joint2 = c->get_joint2_id();
-          data->fext[joint1] = dc->joint1_f;
-          data->fext[joint2] = dc->joint2_f;
-        } else {
+        for (size_t i = 0; i < m_i->contact->get_nf(); ++i) {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+              state_->get_pinocchio()
+                  ->frames[d_i->force_datas[i].frame]
+                  .parentJoint;
 #else
           const pinocchio::JointIndex joint =
-              state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+              state_->get_pinocchio()
+                  ->frames[d_i->force_datas[i]->frame]
+                  .parent;
 #endif
-          data->fext[joint] = d_i->force_datas[0].fext;  // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+          data->fext[joint] = d_i->force_datas[i].fext;
         }
         nc += nc_i;
       } else {

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -399,14 +399,7 @@ void ContactModelMultipleTpl<Scalar>::updateRneaDiff(
     assert_pretty(it_m->first == it_d->first,
                   "it doesn't match the contact name between data and model");
     if (m_i->active) {
-      switch (m_i->contact->get_type()) {
-        case pinocchio::ReferenceFrame::LOCAL:
-          break;
-        case pinocchio::ReferenceFrame::WORLD:
-        case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
-          pinocchio.dtau_dq += d_i->dtau_dq;
-          break;
-      }
+      pinocchio.dtau_dq += d_i->dtau_dq;
     }
   }
 }

--- a/include/crocoddyl/multibody/force-base.hpp
+++ b/include/crocoddyl/multibody/force-base.hpp
@@ -22,19 +22,48 @@ struct ForceDataAbstractTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
-
-  typedef typename pinocchio::SE3Tpl<Scalar> SE3;
-  typedef typename pinocchio::ForceTpl<Scalar> Force;
+  typedef pinocchio::SE3Tpl<Scalar> SE3;
+  typedef typename pinocchio::SE3Tpl<Scalar>::ActionMatrixType SE3ActionMatrix;
+  typedef pinocchio::MotionTpl<Scalar> Motion;
+  typedef pinocchio::ForceTpl<Scalar> Force;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef typename MathBase::Matrix3s Matrix3s;
+  typedef typename MathBase::Matrix6xs Matrix6xs;
+  typedef typename MathBase::Matrix6s Matrix6s;
+  typedef typename MathBase::MatrixXs MatrixXs;
 
   template <template <typename Scalar> class Model>
-  ForceDataAbstractTpl(Model<Scalar>* const model)
+  explicit ForceDataAbstractTpl(Model<Scalar>* const model)
       : frame(0),
         type(model->get_type()),
         jMf(SE3::Identity()),
         fXj(jMf.inverse().toActionMatrix()),
         f(Force::Zero()),
-        fext(Force::Zero()) {}
-  virtual ~ForceDataAbstractTpl() {}
+        fext(Force::Zero()),
+        oMf(SE3::Identity()),
+        fvf(Motion::Zero()),
+        faf(Motion::Zero()),
+        v_partial_dq(6, model->get_state()->get_nv()),
+        v_partial_dv(6, model->get_state()->get_nv()),
+        a_partial_dq(6, model->get_state()->get_nv()),
+        a_partial_dv(6, model->get_state()->get_nv()),
+        a_partial_da(6, model->get_state()->get_nv()),
+        f_v_partial_dq(6, model->get_state()->get_nv()),
+        f_a_partial_dq(6, model->get_state()->get_nv()),
+        f_a_partial_dv(6, model->get_state()->get_nv()),
+        jJj(6, model->get_state()->get_nv()),
+        fJf(6, model->get_state()->get_nv()) {
+    v_partial_dq.setZero();
+    v_partial_dv.setZero();
+    a_partial_dq.setZero();
+    a_partial_dv.setZero();
+    a_partial_da.setZero();
+    f_v_partial_dq.setZero();
+    f_a_partial_dq.setZero();
+    f_a_partial_dv.setZero();
+    jJj.setZero();
+    fJf.setZero();
+  }
 
   pinocchio::FrameIndex frame;     //!< Frame index of the contact frame
   pinocchio::ReferenceFrame type;  //!< Type of contact
@@ -43,6 +72,28 @@ struct ForceDataAbstractTpl {
                                        // contact force to the joint torques
   Force f;     //!< Contact force expressed in the coordinate defined by type
   Force fext;  //!< External spatial force at the parent joint level
+  SE3 oMf;     //<! Placement in the world frame
+  Motion fvf;  //<! Frame velocity
+  Motion faf;  //<! Frame acceleration
+
+  Matrix6xs v_partial_dq;  //!< Partial derivative of velcoity w.r.t. the joint
+                           //!< configuration
+  Matrix6xs v_partial_dv;  //!< Partial derivative of velcoity w.r.t. the joint
+                           //!< velocity
+  Matrix6xs a_partial_dq;  //!< Partial derivative of acceleration w.r.t. the
+                           //!< joint configuration
+  Matrix6xs a_partial_dv;  //!< Partial derivative of acceleration w.r.t. the
+                           //!< joint velocity
+  Matrix6xs a_partial_da;  //!< Partial derivative of acceleration w.r.t. the
+                           //!< joint acceleration
+  Matrix6xs f_v_partial_dq;  //!< Partial derivative of velocity w.r.t. the
+                             //!< joint configuration in local frame
+  Matrix6xs f_a_partial_dq;  //!< Partial derivative of acceleration w.r.t. the
+                             //!< joint configuration in local frame
+  Matrix6xs f_a_partial_dv;  //!< Partial derivative of acceleration w.r.t. the
+                             //!< joint velocity in local frame
+  MatrixXs jJj;              //<! Joint jacobian
+  MatrixXs fJf;              //<! Frame jacobian
 };
 
 template <typename _Scalar>
@@ -55,9 +106,7 @@ struct InteractionDataAbstractTpl {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   template <template <typename Scalar> class Model>
-  InteractionDataAbstractTpl(Model<Scalar>* const model,
-                             pinocchio::DataTpl<Scalar>* const data,
-                             const int nf)
+  InteractionDataAbstractTpl(Model<Scalar>* const model, const int nf)
       : nf(nf),
         force_datas(nf, ForceDataAbstractTpl<Scalar>(model)),
         df_dx(model->get_nc(), model->get_state()->get_ndx()),
@@ -69,7 +118,7 @@ struct InteractionDataAbstractTpl {
   virtual ~InteractionDataAbstractTpl() {}
 
   std::size_t nf;
-  std::vector<ForceDataAbstract> force_datas;
+  std::vector<ForceDataAbstractTpl<Scalar>> force_datas;
 
   MatrixXs df_dx;  //!< Jacobian of the contact forces expressed in the
                    //!< coordinate defined by type

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -191,6 +191,11 @@ class ContactModel6DTpl;
 template <typename Scalar>
 struct ContactData6DTpl;
 
+template <typename Scalar>
+class ContactModel6DLoopTpl;
+template <typename Scalar>
+struct ContactData6DLoopTpl;
+
 // friction
 template <typename Scalar>
 class FrictionConeTpl;
@@ -362,6 +367,8 @@ typedef ContactModel3DTpl<double> ContactModel3D;
 typedef ContactData3DTpl<double> ContactData3D;
 typedef ContactModel6DTpl<double> ContactModel6D;
 typedef ContactData6DTpl<double> ContactData6D;
+typedef ContactModel6DLoopTpl<double> ContactModel6DLoop;
+typedef ContactData6DLoopTpl<double> ContactData6DLoop;
 
 typedef StateMultibodyTpl<double> StateMultibody;
 

--- a/include/crocoddyl/multibody/impulse-base.hpp
+++ b/include/crocoddyl/multibody/impulse-base.hpp
@@ -61,6 +61,8 @@ class ImpulseModelAbstractTpl {
   DEPRECATED("Use get_nc().", std::size_t get_ni() const;)
   std::size_t get_nu() const;
 
+  std::size_t get_nf() const;
+
   /**
    * @brief Return the reference frame id
    */
@@ -118,16 +120,14 @@ struct ImpulseDataAbstractTpl : public InteractionDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   ImpulseDataAbstractTpl(Model<Scalar>* const model,
                          pinocchio::DataTpl<Scalar>* const data)
-      : InteractionDataAbstractTpl<Scalar>(model, data, 1),
+      : InteractionDataAbstractTpl<Scalar>(model, 1),
         pinocchio(data),
         dv0_dq(model->get_nc(), model->get_state()->get_nv()),
         dtau_dq(model->get_state()->get_nv(), model->get_state()->get_nv()),
-        Jc(model->get_nc(), model->get_state()->get_nv()),
-        df_dx(model->get_nc(), model->get_state()->get_ndx()) {
+        Jc(model->get_nc(), model->get_state()->get_nv()) {
     dv0_dq.setZero();
     dtau_dq.setZero();
     Jc.setZero();
-    df_dx.setZero();
   }
   virtual ~ImpulseDataAbstractTpl() {}
 
@@ -135,14 +135,12 @@ struct ImpulseDataAbstractTpl : public InteractionDataAbstractTpl<_Scalar> {
 
   using InteractionDataAbstractTpl<Scalar>::nf;
   using InteractionDataAbstractTpl<Scalar>::force_datas;
+  using InteractionDataAbstractTpl<Scalar>::df_dx;
 
   MatrixXs dv0_dq;
   MatrixXs dtau_dq;
 
   MatrixXs Jc;  //!< Contact Jacobian
-
-  MatrixXs df_dx;  //!< Jacobian of the contact forces expressed in the
-                   //!< coordinate defined by type
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/impulse-base.hxx
+++ b/include/crocoddyl/multibody/impulse-base.hxx
@@ -44,9 +44,10 @@ void ImpulseModelAbstractTpl<Scalar>::updateForceDiff(
 template <typename Scalar>
 void ImpulseModelAbstractTpl<Scalar>::setZeroForce(
     const boost::shared_ptr<ImpulseDataAbstract>& data) const {
-  // TODO(jfoster): there is only ever 1 force data for impulses
-    data->force_datas[0].f.setZero();
-    data->force_datas[0].fext.setZero();
+  ForceDataAbstract fdata =
+      data->force_datas[0];  // only 1 force data for impulses
+  fdata.f.setZero();
+  fdata.fext.setZero();
 }
 
 template <typename Scalar>
@@ -87,6 +88,11 @@ std::size_t ImpulseModelAbstractTpl<Scalar>::get_ni() const {
 template <typename Scalar>
 std::size_t ImpulseModelAbstractTpl<Scalar>::get_nu() const {
   return 0;
+}
+
+template <typename Scalar>
+std::size_t ImpulseModelAbstractTpl<Scalar>::get_nf() const {
+  return 1;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/impulse-base.hxx
+++ b/include/crocoddyl/multibody/impulse-base.hxx
@@ -44,8 +44,9 @@ void ImpulseModelAbstractTpl<Scalar>::updateForceDiff(
 template <typename Scalar>
 void ImpulseModelAbstractTpl<Scalar>::setZeroForce(
     const boost::shared_ptr<ImpulseDataAbstract>& data) const {
-  data->f.setZero();
-  data->fext.setZero();
+  // TODO(jfoster): there is only ever 1 force data for impulses
+    data->force_datas[0].f.setZero();
+    data->force_datas[0].fext.setZero();
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hpp
@@ -112,9 +112,6 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
       : Base(model, data),
         f_local(Force::Zero()),
         dv0_local_dq(3, model->get_state()->get_nv()),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        v_partial_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
@@ -124,9 +121,6 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
 
     v0.setZero();
     dv0_local_dq.setZero();
-    fJf.setZero();
-    v_partial_dq.setZero();
-    v_partial_dv.setZero();
     v0_skew.setZero();
     v0_world_skew.setZero();
     f_skew.setZero();
@@ -142,9 +136,6 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
   Vector3s v0;
   Force f_local;
   Matrix3xs dv0_local_dq;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs v_partial_dv;
   Matrix3s v0_skew;
   Matrix3s v0_world_skew;
   Matrix3s f_skew;

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hpp
@@ -116,10 +116,12 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
         v_partial_dq(6, model->get_state()->get_nv()),
         v_partial_dv(6, model->get_state()->get_nv()),
         fJf_df(3, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf =
-        model->get_state()->get_pinocchio()->frames[model->get_id()].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     v0.setZero();
     dv0_local_dq.setZero();
     fJf.setZero();
@@ -133,12 +135,9 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
 
   using Base::df_dx;
   using Base::dv0_dq;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
   using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   Vector3s v0;
   Force f_local;

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hxx
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hxx
@@ -35,16 +35,16 @@ void ImpulseModel3DTpl<Scalar>::calc(
   pinocchio::updateFramePlacement<Scalar>(*state_->get_pinocchio().get(),
                                           *d->pinocchio, id_);
   pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
-                              id_, pinocchio::LOCAL, d->fJf);
+                              id_, pinocchio::LOCAL, fdata.fJf);
 
   switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
-      data->Jc = d->fJf.template topRows<3>();
+      data->Jc = fdata.fJf.template topRows<3>();
       break;
     case pinocchio::ReferenceFrame::WORLD:
     case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
       data->Jc.noalias() =
-          d->pinocchio->oMf[id_].rotation() * d->fJf.template topRows<3>();
+          d->pinocchio->oMf[id_].rotation() * fdata.fJf.template topRows<3>();
       break;
   }
 }
@@ -64,8 +64,8 @@ void ImpulseModel3DTpl<Scalar>::calcDiff(
 #endif
   pinocchio::getJointVelocityDerivatives(*state_->get_pinocchio().get(),
                                          *d->pinocchio, joint, pinocchio::LOCAL,
-                                         d->v_partial_dq, d->v_partial_dv);
-  d->dv0_local_dq.noalias() = fdata.fXj.template topRows<3>() * d->v_partial_dq;
+                                         fdata.v_partial_dq, fdata.v_partial_dv);
+  d->dv0_local_dq.noalias() = fdata.fXj.template topRows<3>() * fdata.v_partial_dq;
 
   switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
@@ -82,7 +82,7 @@ void ImpulseModel3DTpl<Scalar>::calcDiff(
       d->v0_world_skew.noalias() = d->v0_skew * oRf;
       data->dv0_dq.noalias() = oRf * d->dv0_local_dq;
       data->dv0_dq.noalias() -=
-          d->v0_world_skew * d->fJf.template bottomRows<3>();
+          d->v0_world_skew * fdata.fJf.template bottomRows<3>();
       break;
   }
 }
@@ -110,9 +110,9 @@ void ImpulseModel3DTpl<Scalar>::updateForce(
       d->f_local.angular().setZero();
       fdata.fext = fdata.jMf.act(d->f_local);
       pinocchio::skew(d->f_local.linear(), d->f_skew);
-      d->fJf_df.noalias() = d->f_skew * d->fJf.template bottomRows<3>();
+      d->fJf_df.noalias() = d->f_skew * fdata.fJf.template bottomRows<3>();
       data->dtau_dq.noalias() =
-          -d->fJf.template topRows<3>().transpose() * d->fJf_df;
+          -fdata.fJf.template topRows<3>().transpose() * d->fJf_df;
       break;
   }
 }

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hpp
@@ -118,10 +118,12 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
         v_partial_dq(6, model->get_state()->get_nv()),
         v_partial_dv(6, model->get_state()->get_nv()),
         fJf_df(6, model->get_state()->get_nv()) {
-    frame = model->get_id();
-    jMf =
-        model->get_state()->get_pinocchio()->frames[model->get_id()].placement;
-    fXj = jMf.inverse().toActionMatrix();
+    // There is only one element in the force_datas vector
+    ForceDataAbstract& fdata = force_datas[0];
+    fdata.frame = model->get_id();
+    fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
+    fdata.fXj = fdata.jMf.inverse().toActionMatrix();
+
     fJf.setZero();
     v_partial_dq.setZero();
     v_partial_dv.setZero();
@@ -136,12 +138,9 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
 
   using Base::df_dx;
   using Base::dv0_dq;
-  using Base::f;
-  using Base::frame;
-  using Base::fXj;
   using Base::Jc;
-  using Base::jMf;
   using Base::pinocchio;
+  using Base::force_datas;
 
   SE3 lwaMl;
   Motion v0;

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hpp
@@ -114,9 +114,6 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
         v0(Motion::Zero()),
         f_local(Force::Zero()),
         dv0_local_dq(6, model->get_state()->get_nv()),
-        fJf(6, model->get_state()->get_nv()),
-        v_partial_dq(6, model->get_state()->get_nv()),
-        v_partial_dv(6, model->get_state()->get_nv()),
         fJf_df(6, model->get_state()->get_nv()) {
     // There is only one element in the force_datas vector
     ForceDataAbstract& fdata = force_datas[0];
@@ -124,9 +121,6 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
     fdata.jMf = model->get_state()->get_pinocchio()->frames[fdata.frame].placement;
     fdata.fXj = fdata.jMf.inverse().toActionMatrix();
 
-    fJf.setZero();
-    v_partial_dq.setZero();
-    v_partial_dv.setZero();
     vv_skew.setZero();
     vw_skew.setZero();
     vv_world_skew.setZero();
@@ -146,9 +140,6 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
   Motion v0;
   Force f_local;
   Matrix6xs dv0_local_dq;
-  Matrix6xs fJf;
-  Matrix6xs v_partial_dq;
-  Matrix6xs v_partial_dv;
   Matrix3s vv_skew;
   Matrix3s vw_skew;
   Matrix3s vv_world_skew;

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hxx
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hxx
@@ -34,15 +34,15 @@ void ImpulseModel6DTpl<Scalar>::calc(
   pinocchio::updateFramePlacement<Scalar>(*state_->get_pinocchio().get(),
                                           *d->pinocchio, id_);
   pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio,
-                              id_, pinocchio::LOCAL, d->fJf);
+                              id_, pinocchio::LOCAL, fdata.fJf);
   switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
-      data->Jc = d->fJf;
+      data->Jc = fdata.fJf;
       break;
     case pinocchio::ReferenceFrame::WORLD:
     case pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED:
       d->lwaMl.rotation(d->pinocchio->oMf[id_].rotation());
-      data->Jc.noalias() = d->lwaMl.toActionMatrix() * d->fJf;
+      data->Jc.noalias() = d->lwaMl.toActionMatrix() * fdata.fJf;
       break;
   }
 }
@@ -62,8 +62,8 @@ void ImpulseModel6DTpl<Scalar>::calcDiff(
 #endif
   pinocchio::getJointVelocityDerivatives(*state_->get_pinocchio().get(),
                                          *d->pinocchio, joint, pinocchio::LOCAL,
-                                         d->v_partial_dq, d->v_partial_dv);
-  d->dv0_local_dq.noalias() = fdata.fXj * d->v_partial_dq;
+                                         fdata.v_partial_dq, fdata.v_partial_dv);
+  d->dv0_local_dq.noalias() = fdata.fXj * fdata.v_partial_dq;
 
   switch (type_) {
     case pinocchio::ReferenceFrame::LOCAL:
@@ -80,9 +80,9 @@ void ImpulseModel6DTpl<Scalar>::calcDiff(
       d->vw_world_skew.noalias() = d->vw_skew * oRf;
       data->dv0_dq.noalias() = d->lwaMl.toActionMatrix() * d->dv0_local_dq;
       d->dv0_dq.template topRows<3>().noalias() -=
-          d->vv_world_skew * d->fJf.template bottomRows<3>();
+          d->vv_world_skew * fdata.fJf.template bottomRows<3>();
       d->dv0_dq.template bottomRows<3>().noalias() -=
-          d->vw_world_skew * d->fJf.template bottomRows<3>();
+          d->vw_world_skew * fdata.fJf.template bottomRows<3>();
       break;
   }
 }
@@ -109,10 +109,10 @@ void ImpulseModel6DTpl<Scalar>::updateForce(
       pinocchio::skew(d->f_local.linear(), d->fv_skew);
       pinocchio::skew(d->f_local.angular(), d->fw_skew);
       d->fJf_df.template topRows<3>().noalias() =
-          d->fv_skew * d->fJf.template bottomRows<3>();
+          d->fv_skew * fdata.fJf.template bottomRows<3>();
       d->fJf_df.template bottomRows<3>().noalias() =
-          d->fw_skew * d->fJf.template bottomRows<3>();
-      d->dtau_dq.noalias() = -d->fJf.transpose() * d->fJf_df;
+          d->fw_skew * fdata.fJf.template bottomRows<3>();
+      d->dtau_dq.noalias() = -fdata.fJf.transpose() * d->fJf_df;
       break;
   }
 }

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -182,15 +182,16 @@ void ImpulseModelMultipleTpl<Scalar>::updateForce(
       const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i =
           force.segment(nc, nc_i);
       m_i->impulse->updateForce(d_i, force_i);
+      for (size_t i = 0; i < m_i->impulse->get_nf(); ++i) {
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
-      const pinocchio::JointIndex joint =
-          state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+        const pinocchio::JointIndex joint =
+            state_->get_pinocchio()->frames[d_i->force_datas[i].frame].parentJoint;
 #else
-      const pinocchio::JointIndex joint =
-          state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
-
+        const pinocchio::JointIndex joint =
+            state_->get_pinocchio()->frames[d_i->force_datas[i].frame].parent;
 #endif
-      data->fext[joint] = d_i->force_datas[0].fext;  // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+        data->fext[joint] = d_i->force_datas[i].fext;
+      }
       nc += nc_i;
     } else {
       m_i->impulse->setZeroForce(d_i);

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -184,12 +184,13 @@ void ImpulseModelMultipleTpl<Scalar>::updateForce(
       m_i->impulse->updateForce(d_i, force_i);
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
       const pinocchio::JointIndex joint =
-          state_->get_pinocchio()->frames[d_i->frame].parentJoint;
+          state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parentJoint; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
 #else
       const pinocchio::JointIndex joint =
-          state_->get_pinocchio()->frames[d_i->frame].parent;
+          state_->get_pinocchio()->frames[d_i->force_datas[0].frame].parent; // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
+
 #endif
-      data->fext[joint] = d_i->fext;
+      data->fext[joint] = d_i->force_datas[0].fext;  // TODO(jfoster): clean up force_data indexing and merge logic with 6D loop above
       nc += nc_i;
     } else {
       m_i->impulse->setZeroForce(d_i);

--- a/include/crocoddyl/multibody/numdiff/contact.hpp
+++ b/include/crocoddyl/multibody/numdiff/contact.hpp
@@ -37,7 +37,7 @@ class ContactModelNumDiffTpl : public ContactModelAbstractTpl<_Scalar> {
    *
    * @param model
    */
-  explicit ContactModelNumDiffTpl(const boost::shared_ptr<Base>& model);
+  explicit ContactModelNumDiffTpl(const boost::shared_ptr<Base>& model, const int nf);
 
   /**
    * @brief Default destructor of the ContactModelNumDiff object
@@ -135,7 +135,7 @@ struct ContactDataNumDiffTpl : public ContactDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   explicit ContactDataNumDiffTpl(Model<Scalar>* const model,
                                  pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Base(model, data, 1),
         dx(model->get_state()->get_ndx()),
         xp(model->get_state()->get_nx()) {
     dx.setZero();
@@ -152,7 +152,6 @@ struct ContactDataNumDiffTpl : public ContactDataAbstractTpl<_Scalar> {
 
   using Base::a0;
   using Base::da0_dx;
-  using Base::f;
   using Base::pinocchio;
 
   Scalar x_norm;  //!< Norm of the state vector

--- a/include/crocoddyl/multibody/numdiff/contact.hxx
+++ b/include/crocoddyl/multibody/numdiff/contact.hxx
@@ -14,8 +14,8 @@ namespace crocoddyl {
 
 template <typename Scalar>
 ContactModelNumDiffTpl<Scalar>::ContactModelNumDiffTpl(
-    const boost::shared_ptr<Base>& model)
-    : Base(model->get_state(), model->get_type(), model->get_nc(),
+    const boost::shared_ptr<Base>& model, const int nf)
+    : Base(model->get_state(), model->get_type(), nf, model->get_nc(),
            model->get_nu()),
       model_(model),
       e_jac_(std::sqrt(2.0 * std::numeric_limits<Scalar>::epsilon())) {}

--- a/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
@@ -282,57 +282,59 @@ struct ResidualDataContactCoPPositionTpl
       for (typename ContactModelMultiple::ContactDataContainer::iterator it =
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
-        if (it->second->frame == id) {
-          ContactData3DTpl<Scalar>* d3d =
-              dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ContactData3DTpl<Scalar>* d3d =
+                dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              throw_pretty(
+                  "Domain error: there isn't defined at least a 6d contact for " +
+                  frame_name);
+              break;
+            }
+            ContactData6DTpl<Scalar>* d6d =
+                dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
             throw_pretty(
                 "Domain error: there isn't defined at least a 6d contact for " +
                 frame_name);
             break;
           }
-          ContactData6DTpl<Scalar>* d6d =
-              dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 6d contact for " +
-              frame_name);
-          break;
         }
       }
     } else {
       for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it =
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
-        if (it->second->frame == id) {
-          ImpulseData3DTpl<Scalar>* d3d =
-              dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            found_contact = true;
-            contact = it->second;
+            if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ImpulseData3DTpl<Scalar>* d3d =
+                dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              throw_pretty(
+                  "Domain error: there isn't defined at least a 6d contact for " +
+                  frame_name);
+              break;
+            }
+            ImpulseData6DTpl<Scalar>* d6d =
+                dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
             throw_pretty(
                 "Domain error: there isn't defined at least a 6d contact for " +
                 frame_name);
             break;
           }
-          ImpulseData6DTpl<Scalar>* d6d =
-              dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 6d contact for " +
-              frame_name);
-          break;
-        }
       }
     }
     if (!found_contact) {
@@ -342,7 +344,7 @@ struct ResidualDataContactCoPPositionTpl
   }
 
   pinocchio::DataTpl<Scalar>* pinocchio;                     //!< Pinocchio data
-  boost::shared_ptr<ForceDataAbstractTpl<Scalar> > contact;  //!< Contact force
+  boost::shared_ptr<InteractionDataAbstractTpl<Scalar> > contact;  //!< Contact force
   using Base::r;
   using Base::Ru;
   using Base::Rx;

--- a/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
@@ -283,7 +283,7 @@ struct ResidualDataContactCoPPositionTpl
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ContactData3DTpl<Scalar>* d3d =
                 dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
@@ -307,12 +307,18 @@ struct ResidualDataContactCoPPositionTpl
             break;
           }
         }
+        else {
+          throw_pretty(
+              "Domain error: the contact cop position residual isn't defined "
+              "for contact models with more than one force (nf > 1)");
+        }
       }
     } else {
       for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it =
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
-            if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) {
             ImpulseData3DTpl<Scalar>* d3d =
                 dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
@@ -335,6 +341,12 @@ struct ResidualDataContactCoPPositionTpl
                 frame_name);
             break;
           }
+        }
+        else {
+          throw_pretty(
+              "Domain error: the contact cop position residual isn't defined "
+              "for impulse models with more than one force (nf > 1)");
+        }
       }
     }
     if (!found_contact) {

--- a/include/crocoddyl/multibody/residuals/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-cop-position.hxx
@@ -43,7 +43,7 @@ void ResidualModelContactCoPPositionTpl<Scalar>::calc(
   Data* d = static_cast<Data*>(data.get());
 
   // Compute the residual residual r =  A * f
-  data->r.noalias() = cref_.get_A() * d->contact->f.toVector();
+  data->r.noalias() = cref_.get_A() * d->contact->force_datas[0].f.toVector();
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/residuals/contact-force.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-force.hpp
@@ -277,8 +277,7 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame ==
-              id) {  // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ContactData1DTpl<Scalar>* d1d =
                 dynamic_cast<ContactData1DTpl<Scalar>*>(it->second.get());
             if (d1d != NULL) {
@@ -308,6 +307,12 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
                 frame_name);
             break;
           }
+        } else {
+          // TODO(jfoster): should the contact force residual be defined for
+          // loops?
+          throw_pretty(
+              "Domain error: the contact force residual isn't defined "
+              "for contact models with more than one force (nf > 1)");
         }
       }
     } else {
@@ -315,7 +320,7 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ImpulseData3DTpl<Scalar>* d3d =
                 dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
@@ -337,6 +342,12 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
                 frame_name);
             break;
           }
+        } else {
+          // TODO(jfoster): should the contact force residual be defined for
+          // loops?
+          throw_pretty(
+              "Domain error: the contact force residual isn't defined "
+              "for impulse models with more than one force (nf > 1)");
         }
       }
     }

--- a/include/crocoddyl/multibody/residuals/contact-force.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-force.hpp
@@ -276,62 +276,67 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
       for (typename ContactModelMultiple::ContactDataContainer::iterator it =
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
-        if (it->second->frame == id) {
-          ContactData1DTpl<Scalar>* d1d =
-              dynamic_cast<ContactData1DTpl<Scalar>*>(it->second.get());
-          if (d1d != NULL) {
-            contact_type = Contact1D;
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame ==
+              id) {  // TODO(jfoster): outer if enforces 1 force data
+            ContactData1DTpl<Scalar>* d1d =
+                dynamic_cast<ContactData1DTpl<Scalar>*>(it->second.get());
+            if (d1d != NULL) {
+              contact_type = Contact1D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ContactData3DTpl<Scalar>* d3d =
+                dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              contact_type = Contact3D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ContactData6DTpl<Scalar>* d6d =
+                dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              contact_type = Contact6D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            throw_pretty(
+                "Domain error: there isn't defined at least a 3d contact for " +
+                frame_name);
             break;
           }
-          ContactData3DTpl<Scalar>* d3d =
-              dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            contact_type = Contact3D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          ContactData6DTpl<Scalar>* d6d =
-              dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            contact_type = Contact6D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 3d contact for " +
-              frame_name);
-          break;
         }
       }
     } else {
       for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it =
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
-        if (it->second->frame == id) {
-          ImpulseData3DTpl<Scalar>* d3d =
-              dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            contact_type = Contact3D;
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ImpulseData3DTpl<Scalar>* d3d =
+                dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              contact_type = Contact3D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ImpulseData6DTpl<Scalar>* d6d =
+                dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              contact_type = Contact6D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            throw_pretty(
+                "Domain error: there isn't defined at least a 3d impulse for " +
+                frame_name);
             break;
           }
-          ImpulseData6DTpl<Scalar>* d6d =
-              dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            contact_type = Contact6D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 3d impulse for " +
-              frame_name);
-          break;
         }
       }
     }
@@ -342,7 +347,7 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
     }
   }
 
-  boost::shared_ptr<ForceDataAbstractTpl<Scalar> >
+  boost::shared_ptr<InteractionDataAbstractTpl<Scalar> >
       contact;               //!< Contact force data
   ContactType contact_type;  //!< Type of contact (3D / 6D)
   using Base::r;

--- a/include/crocoddyl/multibody/residuals/contact-force.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-force.hxx
@@ -68,13 +68,13 @@ void ResidualModelContactForceTpl<Scalar>::calc(
   // We transform the force to the contact frame
   switch (d->contact_type) {
     case Contact1D:
-      data->r = ((d->contact->f - fref_).linear()).row(2);
+      data->r = ((d->contact->force_datas[0].f - fref_).linear()).row(2);
       break;
     case Contact3D:
-      data->r = (d->contact->f - fref_).linear();
+      data->r = (d->contact->force_datas[0].f - fref_).linear();
       break;
     case Contact6D:
-      data->r = (d->contact->f - fref_).toVector();
+      data->r = (d->contact->force_datas[0].f - fref_).toVector();
       break;
     default:
       break;

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -261,62 +261,66 @@ struct ResidualDataContactFrictionConeTpl
       for (typename ContactModelMultiple::ContactDataContainer::iterator it =
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
-        if (it->second->frame == id) {
-          ContactData2DTpl<Scalar>* d2d =
-              dynamic_cast<ContactData2DTpl<Scalar>*>(it->second.get());
-          if (d2d != NULL) {
-            contact_type = Contact2D;
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ContactData2DTpl<Scalar>* d2d =
+                dynamic_cast<ContactData2DTpl<Scalar>*>(it->second.get());
+            if (d2d != NULL) {
+              contact_type = Contact2D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ContactData3DTpl<Scalar>* d3d =
+                dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              contact_type = Contact3D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ContactData6DTpl<Scalar>* d6d =
+                dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              contact_type = Contact6D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            throw_pretty(
+                "Domain error: there isn't defined at least a 2d contact for " +
+                frame_name);
             break;
           }
-          ContactData3DTpl<Scalar>* d3d =
-              dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            contact_type = Contact3D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          ContactData6DTpl<Scalar>* d6d =
-              dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            contact_type = Contact6D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 2d contact for " +
-              frame_name);
-          break;
         }
       }
     } else {
       for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it =
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
-        if (it->second->frame == id) {
-          ImpulseData3DTpl<Scalar>* d3d =
-              dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            contact_type = Contact3D;
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ImpulseData3DTpl<Scalar>* d3d =
+                dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              contact_type = Contact3D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            ImpulseData6DTpl<Scalar>* d6d =
+                dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              contact_type = Contact6D;
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
+            throw_pretty(
+                "Domain error: there isn't defined at least a 3d contact for " +
+                frame_name);
             break;
           }
-          ImpulseData6DTpl<Scalar>* d6d =
-              dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            contact_type = Contact6D;
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 3d contact for " +
-              frame_name);
-          break;
         }
       }
     }
@@ -326,7 +330,7 @@ struct ResidualDataContactFrictionConeTpl
     }
   }
 
-  boost::shared_ptr<ForceDataAbstractTpl<Scalar> >
+  boost::shared_ptr<InteractionDataAbstractTpl<Scalar> >
       contact;               //!< Contact force data
   ContactType contact_type;  //!< Type of contact (2D / 3D / 6D)
   using Base::r;

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -262,7 +262,7 @@ struct ResidualDataContactFrictionConeTpl
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ContactData2DTpl<Scalar>* d2d =
                 dynamic_cast<ContactData2DTpl<Scalar>*>(it->second.get());
             if (d2d != NULL) {
@@ -292,6 +292,10 @@ struct ResidualDataContactFrictionConeTpl
                 frame_name);
             break;
           }
+        } else {
+          throw_pretty(
+              "Domain error: the contact friction cone residual isn't defined "
+              "for contact models with more than one force (nf > 1)");
         }
       }
     } else {
@@ -299,7 +303,7 @@ struct ResidualDataContactFrictionConeTpl
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ImpulseData3DTpl<Scalar>* d3d =
                 dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
@@ -321,6 +325,11 @@ struct ResidualDataContactFrictionConeTpl
                 frame_name);
             break;
           }
+        } else {
+          throw_pretty(
+              "Domain error: the contact friction cone residual isn't "
+              "defined for contact models with more than one force "
+              "(nf > 1)");
         }
       }
     }

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
@@ -61,7 +61,7 @@ void ResidualModelContactFrictionConeTpl<Scalar>::calc(
 
   // Compute the residual of the friction cone. Note that we need to transform
   // the force to the contact frame
-  data->r.noalias() = fref_.get_A() * d->contact->f.linear();
+  data->r.noalias() = fref_.get_A() * d->contact->force_datas[0].f.linear();
 }
 
 template <typename Scalar>
@@ -104,7 +104,7 @@ void ResidualModelContactFrictionConeTpl<Scalar>::updateJacobians(
     const boost::shared_ptr<ResidualDataAbstract>& data) {
   Data* d = static_cast<Data*>(data.get());
 
-  const MatrixXs& df_dx = d->contact->df_dx;
+  const MatrixXs& df_dx = d->contact->df_dx;  // TODO(jfoster): we've ensured only 1 data force
   const MatrixXs& df_du = d->contact->df_du;
   const MatrixX3s& A = fref_.get_A();
   switch (d->contact_type) {

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
@@ -104,7 +104,7 @@ void ResidualModelContactFrictionConeTpl<Scalar>::updateJacobians(
     const boost::shared_ptr<ResidualDataAbstract>& data) {
   Data* d = static_cast<Data*>(data.get());
 
-  const MatrixXs& df_dx = d->contact->df_dx;  // TODO(jfoster): we've ensured only 1 data force
+  const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
   const MatrixX3s& A = fref_.get_A();
   switch (d->contact_type) {

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
@@ -268,56 +268,60 @@ struct ResidualDataContactWrenchConeTpl
       for (typename ContactModelMultiple::ContactDataContainer::iterator it =
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
-        if (it->second->frame == id) {
-          ContactData3DTpl<Scalar>* d3d =
-              dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ContactData3DTpl<Scalar>* d3d =
+                dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              throw_pretty(
+                  "Domain error: there isn't defined at least a 6d contact for " +
+                  frame_name);
+              break;
+            }
+            ContactData6DTpl<Scalar>* d6d =
+                dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
             throw_pretty(
                 "Domain error: there isn't defined at least a 6d contact for " +
                 frame_name);
             break;
           }
-          ContactData6DTpl<Scalar>* d6d =
-              dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 6d contact for " +
-              frame_name);
-          break;
         }
       }
     } else {
       for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it =
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
-        if (it->second->frame == id) {
-          ImpulseData3DTpl<Scalar>* d3d =
-              dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
-          if (d3d != NULL) {
-            found_contact = true;
-            contact = it->second;
+        if (it->second->nf == 1) {
+          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+            ImpulseData3DTpl<Scalar>* d3d =
+                dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
+            if (d3d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              throw_pretty(
+                  "Domain error: there isn't defined at least a 6d contact for " +
+                  frame_name);
+              break;
+            }
+            ImpulseData6DTpl<Scalar>* d6d =
+                dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
+            if (d6d != NULL) {
+              found_contact = true;
+              contact = it->second;
+              break;
+            }
             throw_pretty(
                 "Domain error: there isn't defined at least a 6d contact for " +
                 frame_name);
             break;
           }
-          ImpulseData6DTpl<Scalar>* d6d =
-              dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
-          if (d6d != NULL) {
-            found_contact = true;
-            contact = it->second;
-            break;
-          }
-          throw_pretty(
-              "Domain error: there isn't defined at least a 6d contact for " +
-              frame_name);
-          break;
         }
       }
     }
@@ -327,7 +331,7 @@ struct ResidualDataContactWrenchConeTpl
     }
   }
 
-  boost::shared_ptr<ForceDataAbstractTpl<Scalar> >
+  boost::shared_ptr<InteractionDataAbstractTpl<Scalar> >
       contact;  //!< Contact force data
   using Base::r;
   using Base::Ru;

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
@@ -269,14 +269,15 @@ struct ResidualDataContactWrenchConeTpl
                d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ContactData3DTpl<Scalar>* d3d =
                 dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
               found_contact = true;
               contact = it->second;
               throw_pretty(
-                  "Domain error: there isn't defined at least a 6d contact for " +
+                  "Domain error: there isn't defined at least a 6d contact "
+                  "for " +
                   frame_name);
               break;
             }
@@ -292,6 +293,10 @@ struct ResidualDataContactWrenchConeTpl
                 frame_name);
             break;
           }
+        } else {
+          throw_pretty(
+              "Domain error: the contact wrench cone residual isn't defined "
+              "for contact models with more than one force (nf > 1)");
         }
       }
     } else {
@@ -299,14 +304,15 @@ struct ResidualDataContactWrenchConeTpl
                d2->impulses->impulses.begin();
            it != d2->impulses->impulses.end(); ++it) {
         if (it->second->nf == 1) {
-          if (it->second->force_datas[0].frame == id) { // TODO(jfoster): outer if enforces 1 force data
+          if (it->second->force_datas[0].frame == id) {
             ImpulseData3DTpl<Scalar>* d3d =
                 dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
             if (d3d != NULL) {
               found_contact = true;
               contact = it->second;
               throw_pretty(
-                  "Domain error: there isn't defined at least a 6d contact for " +
+                  "Domain error: there isn't defined at least a 6d contact "
+                  "for " +
                   frame_name);
               break;
             }
@@ -322,6 +328,11 @@ struct ResidualDataContactWrenchConeTpl
                 frame_name);
             break;
           }
+        } else {
+          throw_pretty(
+              "Domain error: the contact wrench cone residual isn't "
+              "defined for contact models with more than one force "
+              "(nf > 1)");
         }
       }
     }

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hxx
@@ -57,7 +57,7 @@ void ResidualModelContactWrenchConeTpl<Scalar>::calc(
 
   // Compute the residual of the wrench cone. Note that we need to transform the
   // wrench to the contact frame
-  data->r.noalias() = fref_.get_A() * d->contact->force_datas[0].f.toVector(); // TODO(jfoster): We know there's only 1 force data
+  data->r.noalias() = fref_.get_A() * d->contact->force_datas[0].f.toVector();
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hxx
@@ -57,7 +57,7 @@ void ResidualModelContactWrenchConeTpl<Scalar>::calc(
 
   // Compute the residual of the wrench cone. Note that we need to transform the
   // wrench to the contact frame
-  data->r.noalias() = fref_.get_A() * d->contact->f.toVector();
+  data->r.noalias() = fref_.get_A() * d->contact->force_datas[0].f.toVector(); // TODO(jfoster): We know there's only 1 force data
 }
 
 template <typename Scalar>

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -28,6 +28,7 @@ set(${PROJECT_NAME}_CPP_TESTS
     test_constraints
     test_constraint_manager
     test_contacts
+    test_contacts_loop
     test_controls
     test_impulses
     test_multiple_contacts

--- a/unittest/factory/contact_loop.cpp
+++ b/unittest/factory/contact_loop.cpp
@@ -36,13 +36,14 @@ std::ostream& operator<<(std::ostream& os,
 ContactLoopModelFactory::ContactLoopModelFactory() {}
 ContactLoopModelFactory::~ContactLoopModelFactory() {}
 
-boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactLoopModelFactory::create(
-      ContactLoopModelTypes::Type contact_type,
-      PinocchioModelTypes::Type model_type,
-      const int joint1_id, const pinocchio::SE3 &joint1_placement,
-      const int joint2_id, const pinocchio::SE3 &joint2_placement,
-      Eigen::Vector2d gains,
-      std::size_t nu ) const {
+boost::shared_ptr<crocoddyl::ContactModelAbstract>
+ContactLoopModelFactory::create(ContactLoopModelTypes::Type contact_type,
+                                PinocchioModelTypes::Type model_type,
+                                const int joint1_id,
+                                const pinocchio::SE3& joint1_placement,
+                                const int joint2_id,
+                                const pinocchio::SE3& joint2_placement,
+                                Eigen::Vector2d gains, std::size_t nu) const {
   PinocchioModelFactory model_factory(model_type);
   boost::shared_ptr<crocoddyl::StateMultibody> state =
       boost::make_shared<crocoddyl::StateMultibody>(model_factory.create());
@@ -53,8 +54,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactLoopModelFactory::crea
   switch (contact_type) {
     case ContactLoopModelTypes::ContactModel6DLoop_LOCAL:
       contact = boost::make_shared<crocoddyl::ContactModel6DLoop>(
-          state, joint1_id, joint1_placement, 
-          joint2_id, joint2_placement,
+          state, joint1_id, joint1_placement, joint2_id, joint2_placement,
           pinocchio::ReferenceFrame::LOCAL, nu, gains);
       break;
     default:
@@ -64,20 +64,24 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactLoopModelFactory::crea
   return contact;
 }
 
-boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_loop_contact() {
+boost::shared_ptr<crocoddyl::ContactModelAbstract>
+create_random_loop_contact() {
   static bool once = true;
   if (once) {
     srand((unsigned)time(NULL));
     once = false;
   }
   boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
-  ContactLoopModelFactory factory;;
+  ContactLoopModelFactory factory;
+  ;
   if (rand() % 1 == 0) {
-    contact = factory.create(ContactLoopModelTypes::ContactModel6DLoop_LOCAL,
-                            PinocchioModelTypes::RandomHumanoid,
-                            0, pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
-                            1, pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
-                            Eigen::Vector2d::Random());
+    contact = factory.create(
+        ContactLoopModelTypes::ContactModel6DLoop_LOCAL,
+        PinocchioModelTypes::RandomHumanoid, 0,
+        pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
+        1,
+        pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
+        Eigen::Vector2d::Random());
   }
   return contact;
 }

--- a/unittest/factory/contact_loop.cpp
+++ b/unittest/factory/contact_loop.cpp
@@ -1,0 +1,86 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "contact_loop.hpp"
+
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/contacts/contact-6d-loop.hpp"
+
+namespace crocoddyl {
+namespace unittest {
+
+const std::vector<ContactLoopModelTypes::Type> ContactLoopModelTypes::all(
+    ContactLoopModelTypes::init_all());
+
+std::ostream& operator<<(std::ostream& os,
+                         const ContactLoopModelTypes::Type& type) {
+  switch (type) {
+    case ContactLoopModelTypes::ContactModel6DLoop_LOCAL:
+      os << "ContactLoopModel6D_LOCAL";
+      break;
+    case ContactLoopModelTypes::NbContactModelTypes:
+      os << "NbContactModelTypes";
+      break;
+    default:
+      os << "Unknown type";
+      break;
+  }
+  return os;
+}
+
+ContactLoopModelFactory::ContactLoopModelFactory() {}
+ContactLoopModelFactory::~ContactLoopModelFactory() {}
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactLoopModelFactory::create(
+      ContactLoopModelTypes::Type contact_type,
+      PinocchioModelTypes::Type model_type,
+      const int joint1_id, const pinocchio::SE3 &joint1_placement,
+      const int joint2_id, const pinocchio::SE3 &joint2_placement,
+      Eigen::Vector2d gains,
+      std::size_t nu ) const {
+  PinocchioModelFactory model_factory(model_type);
+  boost::shared_ptr<crocoddyl::StateMultibody> state =
+      boost::make_shared<crocoddyl::StateMultibody>(model_factory.create());
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
+  if (nu == std::numeric_limits<std::size_t>::max()) {
+    nu = state->get_nv();
+  }
+  switch (contact_type) {
+    case ContactLoopModelTypes::ContactModel6DLoop_LOCAL:
+      contact = boost::make_shared<crocoddyl::ContactModel6DLoop>(
+          state, joint1_id, joint1_placement, 
+          joint2_id, joint2_placement,
+          pinocchio::ReferenceFrame::LOCAL, nu, gains);
+      break;
+    default:
+      throw_pretty(__FILE__ ": Wrong ContactLoopModelTypes::Type given");
+      break;
+  }
+  return contact;
+}
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_loop_contact() {
+  static bool once = true;
+  if (once) {
+    srand((unsigned)time(NULL));
+    once = false;
+  }
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
+  ContactLoopModelFactory factory;;
+  if (rand() % 1 == 0) {
+    contact = factory.create(ContactLoopModelTypes::ContactModel6DLoop_LOCAL,
+                            PinocchioModelTypes::RandomHumanoid,
+                            0, pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
+                            1, pinocchio::SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Random()),
+                            Eigen::Vector2d::Random());
+  }
+  return contact;
+}
+
+}  // namespace unittest
+}  // namespace crocoddyl

--- a/unittest/factory/contact_loop.hpp
+++ b/unittest/factory/contact_loop.hpp
@@ -1,0 +1,63 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University, 
+//                          LAAS-CNRS
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CONTACTS_LOOP_FACTORY_HPP_
+#define CROCODDYL_CONTACTS_LOOP_FACTORY_HPP_
+
+#include <iostream>
+#include <limits>
+
+#include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+#include "crocoddyl/multibody/numdiff/contact.hpp"
+#include "state.hpp"
+
+namespace crocoddyl {
+namespace unittest {
+
+struct ContactLoopModelTypes {
+  enum Type {
+    ContactModel6DLoop_LOCAL,
+    NbContactModelTypes
+  };
+  static std::vector<Type> init_all() {
+    std::vector<Type> v;
+    v.reserve(NbContactModelTypes);
+    for (int i = 0; i < NbContactModelTypes; ++i) {
+      v.push_back((Type)i);
+    }
+    return v;
+  }
+  static const std::vector<Type> all;
+};
+
+std::ostream& operator<<(std::ostream& os, const ContactLoopModelTypes::Type& type);
+
+class ContactLoopModelFactory {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit ContactLoopModelFactory();
+  ~ContactLoopModelFactory();
+
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> create(
+      ContactLoopModelTypes::Type contact_type,
+      PinocchioModelTypes::Type model_type,
+      const int joint1_id, const pinocchio::SE3 &joint1_placement,
+      const int joint2_id, const pinocchio::SE3 &joint2_placement,
+      Eigen::Vector2d gains,
+      std::size_t nu = std::numeric_limits<std::size_t>::max()) const;
+};
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_loop_contact();
+
+}  // namespace unittest
+}  // namespace crocoddyl
+
+#endif  // CROCODDYL_CONTACTS_LOOP_FACTORY_HPP_

--- a/unittest/factory/contact_loop.hpp
+++ b/unittest/factory/contact_loop.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University, 
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University,
 //                          LAAS-CNRS
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -22,10 +22,7 @@ namespace crocoddyl {
 namespace unittest {
 
 struct ContactLoopModelTypes {
-  enum Type {
-    ContactModel6DLoop_LOCAL,
-    NbContactModelTypes
-  };
+  enum Type { ContactModel6DLoop_LOCAL, NbContactModelTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.reserve(NbContactModelTypes);
@@ -37,7 +34,8 @@ struct ContactLoopModelTypes {
   static const std::vector<Type> all;
 };
 
-std::ostream& operator<<(std::ostream& os, const ContactLoopModelTypes::Type& type);
+std::ostream& operator<<(std::ostream& os,
+                         const ContactLoopModelTypes::Type& type);
 
 class ContactLoopModelFactory {
  public:
@@ -48,10 +46,9 @@ class ContactLoopModelFactory {
 
   boost::shared_ptr<crocoddyl::ContactModelAbstract> create(
       ContactLoopModelTypes::Type contact_type,
-      PinocchioModelTypes::Type model_type,
-      const int joint1_id, const pinocchio::SE3 &joint1_placement,
-      const int joint2_id, const pinocchio::SE3 &joint2_placement,
-      Eigen::Vector2d gains,
+      PinocchioModelTypes::Type model_type, const int joint1_id,
+      const pinocchio::SE3& joint1_placement, const int joint2_id,
+      const pinocchio::SE3& joint2_placement, Eigen::Vector2d gains,
       std::size_t nu = std::numeric_limits<std::size_t>::max()) const;
 };
 

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -84,7 +84,7 @@ void test_partial_derivatives_against_numdiff(
   BOOST_CHECK((data->g - data_num_diff->g).isZero(tol));
   BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
   BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_REQUIRE((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
     BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -84,7 +84,7 @@ void test_partial_derivatives_against_numdiff(
   BOOST_CHECK((data->g - data_num_diff->g).isZero(tol));
   BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
   BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
-  BOOST_REQUIRE((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
     BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -75,7 +75,7 @@ void test_calc_fetch_jacobians(ContactModelTypes::Type contact_type,
     BOOST_CHECK(!data->a0.isZero());
   }
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -112,7 +112,7 @@ void test_calc_diff_fetch_derivatives(ContactModelTypes::Type contact_type,
     BOOST_CHECK(!data->a0.isZero());
     BOOST_CHECK(!data->da0_dx.isZero());
   }
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -134,16 +134,14 @@ void test_update_force(ContactModelTypes::Type contact_type,
   // Create a random force and update it
   Eigen::VectorXd f = Eigen::VectorXd::Random(data->Jc.rows());
   model->updateForce(data, f);
-  boost::shared_ptr<crocoddyl::ContactModel3D> m =
-      boost::static_pointer_cast<crocoddyl::ContactModel3D>(model);
 
   // Check that nothing has been computed and that all value are initialized to
   // 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(!data->f.toVector().isZero());
-  BOOST_CHECK(!data->fext.toVector().isZero());
+  BOOST_CHECK(!data->force_datas[0].f.toVector().isZero());
+  BOOST_CHECK(!data->force_datas[0].fext.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -174,8 +172,8 @@ void test_update_force_diff(ContactModelTypes::Type contact_type,
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->fext.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].fext.toVector().isZero());
   BOOST_CHECK(!data->df_dx.isZero());
   BOOST_CHECK(!data->df_du.isZero());
 }
@@ -198,7 +196,7 @@ void test_partial_derivatives_against_numdiff(
       model->createData(&pinocchio_data);
 
   // Create the equivalent num diff model and data.
-  crocoddyl::ContactModelNumDiff model_num_diff(model);
+  crocoddyl::ContactModelNumDiff model_num_diff(model, model->get_nf());
   const boost::shared_ptr<crocoddyl::ContactDataAbstract>& data_num_diff =
       model_num_diff.createData(&pinocchio_data);
 

--- a/unittest/test_contacts_loop.cpp
+++ b/unittest/test_contacts_loop.cpp
@@ -28,10 +28,8 @@ void test_construct_data(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        0, pinocchio::SE3::Identity(),
-        0, pinocchio::SE3::Identity(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 0, pinocchio::SE3::Identity(), 0,
+                     pinocchio::SE3::Identity(), Eigen::Vector2d::Random());
 
   // Run the print function
   std::ostringstream tmp;
@@ -50,10 +48,8 @@ void test_calc_fetch_jacobians(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        1, pinocchio::SE3::Random(),
-        2, pinocchio::SE3::Random(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Random(), 2,
+                     pinocchio::SE3::Random(), Eigen::Vector2d::Random());
 
   // create the corresponding data object
   const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
@@ -88,10 +84,8 @@ void test_calc_diff_fetch_derivatives(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        1, pinocchio::SE3::Random(),
-        2, pinocchio::SE3::Random(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Random(), 2,
+                     pinocchio::SE3::Random(), Eigen::Vector2d::Random());
 
   // create the corresponding data object
   const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
@@ -128,10 +122,8 @@ void test_update_force(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        1, pinocchio::SE3::Random(),
-        2, pinocchio::SE3::Random(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Random(), 2,
+                     pinocchio::SE3::Random(), Eigen::Vector2d::Random());
 
   // create the corresponding data object
   const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
@@ -160,10 +152,8 @@ void test_update_force_diff(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        1, pinocchio::SE3::Random(),
-        2, pinocchio::SE3::Random(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Random(), 2,
+                     pinocchio::SE3::Random(), Eigen::Vector2d::Random());
 
   // create the corresponding data object
   const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
@@ -198,10 +188,8 @@ void test_partial_derivatives_against_numdiff(
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 
-        0, pinocchio::SE3::Identity(),
-        0, pinocchio::SE3::Identity(),
-        Eigen::Vector2d::Random());
+      factory.create(contact_type, model_type, 0, pinocchio::SE3::Identity(), 0,
+                     pinocchio::SE3::Identity(), Eigen::Vector2d::Random());
 
   // create the corresponding data object
   pinocchio::Model& pinocchio_model =
@@ -262,15 +250,16 @@ void register_contact_model_unit_tests(ContactLoopModelTypes::Type contact_type,
 }
 
 bool init_function() {
-  for (size_t contact_type = 0; contact_type < ContactLoopModelTypes::all.size();
-       ++contact_type) {
+  for (size_t contact_type = 0;
+       contact_type < ContactLoopModelTypes::all.size(); ++contact_type) {
     for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size();
          ++model_type) {
-            if (model_type == PinocchioModelTypes::Hector) {
-                continue;
-            }
-            register_contact_model_unit_tests(ContactLoopModelTypes::all[contact_type],
-                                        PinocchioModelTypes::all[model_type]);
+      if (model_type == PinocchioModelTypes::Hector) {
+        continue;
+      }
+      register_contact_model_unit_tests(
+          ContactLoopModelTypes::all[contact_type],
+          PinocchioModelTypes::all[model_type]);
     }
   }
   return true;

--- a/unittest/test_contacts_loop.cpp
+++ b/unittest/test_contacts_loop.cpp
@@ -28,7 +28,7 @@ void test_construct_data(ContactLoopModelTypes::Type contact_type,
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 0, pinocchio::SE3::Identity(), 0,
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Identity(), 2,
                      pinocchio::SE3::Identity(), Eigen::Vector2d::Random());
 
   // Run the print function
@@ -188,7 +188,7 @@ void test_partial_derivatives_against_numdiff(
   // create the model
   ContactLoopModelFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
-      factory.create(contact_type, model_type, 0, pinocchio::SE3::Identity(), 0,
+      factory.create(contact_type, model_type, 1, pinocchio::SE3::Identity(), 2,
                      pinocchio::SE3::Identity(), Eigen::Vector2d::Random());
 
   // create the corresponding data object

--- a/unittest/test_contacts_loop.cpp
+++ b/unittest/test_contacts_loop.cpp
@@ -74,7 +74,7 @@ void test_calc_fetch_jacobians(ContactLoopModelTypes::Type contact_type,
     BOOST_CHECK(!data->a0.isZero());
   }
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -112,7 +112,7 @@ void test_calc_diff_fetch_derivatives(ContactLoopModelTypes::Type contact_type,
     BOOST_CHECK(!data->a0.isZero());
     BOOST_CHECK(!data->da0_dx.isZero());
   }
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -141,8 +141,8 @@ void test_update_force(ContactLoopModelTypes::Type contact_type,
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(!data->f.toVector().isZero());
-  BOOST_CHECK(!data->fext.toVector().isZero());
+  BOOST_CHECK(!data->force_datas[0].f.toVector().isZero());
+  BOOST_CHECK(!data->force_datas[0].fext.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());
 }
@@ -174,8 +174,8 @@ void test_update_force_diff(ContactLoopModelTypes::Type contact_type,
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->fext.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].fext.toVector().isZero());
   BOOST_CHECK(!data->df_dx.isZero());
   BOOST_CHECK(!data->df_du.isZero());
 }
@@ -199,7 +199,7 @@ void test_partial_derivatives_against_numdiff(
       model->createData(&pinocchio_data);
 
   // Create the equivalent num diff model and data.
-  crocoddyl::ContactModelNumDiff model_num_diff(model);
+  crocoddyl::ContactModelNumDiff model_num_diff(model, model->get_nf());
   const boost::shared_ptr<crocoddyl::ContactDataAbstract>& data_num_diff =
       model_num_diff.createData(&pinocchio_data);
 

--- a/unittest/test_contacts_loop.cpp
+++ b/unittest/test_contacts_loop.cpp
@@ -1,0 +1,281 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
+#include "crocoddyl/multibody/contacts/contact-6d-loop.hpp"
+#include "factory/contact_loop.hpp"
+#include "unittest_common.hpp"
+
+using namespace crocoddyl::unittest;
+using namespace boost::unit_test;
+
+//----------------------------------------------------------------------------//
+
+void test_construct_data(ContactLoopModelTypes::Type contact_type,
+                         PinocchioModelTypes::Type model_type) {
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        0, pinocchio::SE3::Identity(),
+        0, pinocchio::SE3::Identity(),
+        Eigen::Vector2d::Random());
+
+  // Run the print function
+  std::ostringstream tmp;
+  tmp << *model;
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
+      model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+}
+
+void test_calc_fetch_jacobians(ContactLoopModelTypes::Type contact_type,
+                               PinocchioModelTypes::Type model_type) {
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        1, pinocchio::SE3::Random(),
+        2, pinocchio::SE3::Random(),
+        Eigen::Vector2d::Random());
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
+      model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+
+  // Compute the jacobian and check that the impulse model fetch it.
+  Eigen::VectorXd x = model->get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(pinocchio_model.get(),
+                                          &pinocchio_data, x);
+
+  // Getting the jacobian from the model
+  model->calc(data, x);
+
+  // Check that only the Jacobian has been filled
+  BOOST_CHECK(!data->Jc.isZero());
+  if (model_type !=
+      PinocchioModelTypes::Hector) {  // this is due to Hector is a single rigid
+                                      // body system.
+    BOOST_CHECK(!data->a0.isZero());
+  }
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_calc_diff_fetch_derivatives(ContactLoopModelTypes::Type contact_type,
+                                      PinocchioModelTypes::Type model_type) {
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        1, pinocchio::SE3::Random(),
+        2, pinocchio::SE3::Random(),
+        Eigen::Vector2d::Random());
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
+      model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+
+  // Compute the jacobian and check that the impulse model fetch it.
+  Eigen::VectorXd x = model->get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(pinocchio_model.get(),
+                                          &pinocchio_data, x);
+
+  // Getting the jacobian from the model
+  model->calc(data, x);
+  model->calcDiff(data, x);
+
+  // Check that nothing has been computed and that all value are initialized to
+  // 0
+  BOOST_CHECK(!data->Jc.isZero());
+  if (model_type !=
+      PinocchioModelTypes::Hector) {  // this is due to Hector is a single rigid
+                                      // body system.
+    BOOST_CHECK(!data->a0.isZero());
+    BOOST_CHECK(!data->da0_dx.isZero());
+  }
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_update_force(ContactLoopModelTypes::Type contact_type,
+                       PinocchioModelTypes::Type model_type) {
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        1, pinocchio::SE3::Random(),
+        2, pinocchio::SE3::Random(),
+        Eigen::Vector2d::Random());
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
+      model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+
+  // Create a random force and update it
+  Eigen::VectorXd f = Eigen::VectorXd::Random(data->Jc.rows());
+  model->updateForce(data, f);
+
+  // Check that nothing has been computed and that all value are initialized to
+  // 0
+  BOOST_CHECK(data->Jc.isZero());
+  BOOST_CHECK(data->a0.isZero());
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(!data->f.toVector().isZero());
+  BOOST_CHECK(!data->fext.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_update_force_diff(ContactLoopModelTypes::Type contact_type,
+                            PinocchioModelTypes::Type model_type) {
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        1, pinocchio::SE3::Random(),
+        2, pinocchio::SE3::Random(),
+        Eigen::Vector2d::Random());
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model =
+      model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+
+  // Create a random force and update it
+  Eigen::MatrixXd df_dx =
+      Eigen::MatrixXd::Random(data->df_dx.rows(), data->df_dx.cols());
+  Eigen::MatrixXd df_du =
+      Eigen::MatrixXd::Random(data->df_du.rows(), data->df_du.cols());
+  model->updateForceDiff(data, df_dx, df_du);
+
+  // Check that nothing has been computed and that all value are initialized to
+  // 0
+  BOOST_CHECK(data->Jc.isZero());
+  BOOST_CHECK(data->a0.isZero());
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->fext.toVector().isZero());
+  BOOST_CHECK(!data->df_dx.isZero());
+  BOOST_CHECK(!data->df_du.isZero());
+}
+
+void test_partial_derivatives_against_numdiff(
+    ContactLoopModelTypes::Type contact_type,
+    PinocchioModelTypes::Type model_type) {
+  using namespace boost::placeholders;
+
+  // create the model
+  ContactLoopModelFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model =
+      factory.create(contact_type, model_type, 
+        0, pinocchio::SE3::Identity(),
+        0, pinocchio::SE3::Identity(),
+        Eigen::Vector2d::Random());
+
+  // create the corresponding data object
+  pinocchio::Model& pinocchio_model =
+      *model->get_state()->get_pinocchio().get();
+  pinocchio::Data pinocchio_data(pinocchio_model);
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data =
+      model->createData(&pinocchio_data);
+
+  // Create the equivalent num diff model and data.
+  crocoddyl::ContactModelNumDiff model_num_diff(model);
+  const boost::shared_ptr<crocoddyl::ContactDataAbstract>& data_num_diff =
+      model_num_diff.createData(&pinocchio_data);
+
+  // Generating random values for the state
+  const Eigen::VectorXd x = model->get_state()->rand();
+
+  // Compute all the pinocchio function needed for the models.
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
+
+  // set the function that needs to be called at every step of the numdiff
+  std::vector<crocoddyl::ContactModelNumDiff::ReevaluationFunction> reevals;
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio,
+                                &pinocchio_model, &pinocchio_data, _1, _2));
+  model_num_diff.set_reevals(reevals);
+
+  // Computing the contact derivatives
+  model->calc(data, x);
+  model->calcDiff(data, x);
+  model_num_diff.calc(data_num_diff, x);
+  model_num_diff.calcDiff(data_num_diff, x);
+  // Tolerance defined as in
+  // http://www.it.uom.gr/teaching/linearalgebra/NumericalRecipiesInC/c5-7.pdf
+  double tol = std::pow(model_num_diff.get_disturbance(), 1. / 3.);
+  BOOST_CHECK((data->da0_dx - data_num_diff->da0_dx).isZero(tol));
+}
+
+//----------------------------------------------------------------------------//
+
+void register_contact_model_unit_tests(ContactLoopModelTypes::Type contact_type,
+                                       PinocchioModelTypes::Type model_type) {
+  boost::test_tools::output_test_stream test_name;
+  test_name << "test_" << contact_type << "_" << model_type;
+  std::cout << "Running " << test_name.str() << std::endl;
+  test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(
+      boost::bind(&test_construct_data, contact_type, model_type)));
+  ts->add(BOOST_TEST_CASE(
+      boost::bind(&test_calc_fetch_jacobians, contact_type, model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_fetch_derivatives,
+                                      contact_type, model_type)));
+  ts->add(BOOST_TEST_CASE(
+      boost::bind(&test_update_force, contact_type, model_type)));
+  ts->add(BOOST_TEST_CASE(
+      boost::bind(&test_update_force_diff, contact_type, model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff,
+                                      contact_type, model_type)));
+  framework::master_test_suite().add(ts);
+}
+
+bool init_function() {
+  for (size_t contact_type = 0; contact_type < ContactLoopModelTypes::all.size();
+       ++contact_type) {
+    for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size();
+         ++model_type) {
+            if (model_type == PinocchioModelTypes::Hector) {
+                continue;
+            }
+            register_contact_model_unit_tests(ContactLoopModelTypes::all[contact_type],
+                                        PinocchioModelTypes::all[model_type]);
+    }
+  }
+  return true;
+}
+
+int main(int argc, char** argv) {
+  return ::boost::unit_test::unit_test_main(&init_function, argc, argv);
+}

--- a/unittest/test_impulses.cpp
+++ b/unittest/test_impulses.cpp
@@ -70,7 +70,7 @@ void test_calc_fetch_jacobians(ImpulseModelTypes::Type impulse_type,
   // Check that only the Jacobian has been filled
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
 }
 
@@ -111,7 +111,7 @@ void test_calc_diff_fetch_derivatives(ImpulseModelTypes::Type impulse_type,
   } else {
     BOOST_CHECK(!data->dv0_dq.isZero());
   }
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
 }
 
@@ -139,7 +139,7 @@ void test_update_force(ImpulseModelTypes::Type impulse_type,
   // 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
-  BOOST_CHECK(!data->f.toVector().isZero());
+  BOOST_CHECK(!data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
 }
 
@@ -166,7 +166,7 @@ void test_update_force_diff(ImpulseModelTypes::Type impulse_type,
   // 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->force_datas[0].f.toVector().isZero());
   BOOST_CHECK(!data->df_dx.isZero());
 }
 

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -472,7 +472,7 @@ void test_updateForce() {
   crocoddyl::ContactModelMultiple::ContactDataContainer::iterator it_d, end_d;
   for (it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_d != end_d; ++it_d) {
-    BOOST_CHECK(!it_d->second->f.toVector().isZero());
+    BOOST_CHECK(!it_d->second->force_datas[0].f.toVector().isZero());  // TODO(jfoster): need to modify test logic to go through all forces (should only ever be more than one for loop model)
   }
 }
 

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -472,7 +472,9 @@ void test_updateForce() {
   crocoddyl::ContactModelMultiple::ContactDataContainer::iterator it_d, end_d;
   for (it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_d != end_d; ++it_d) {
-    BOOST_CHECK(!it_d->second->force_datas[0].f.toVector().isZero());  // TODO(jfoster): need to modify test logic to go through all forces (should only ever be more than one for loop model)
+    for (int i = 0; i < it_d->second->nf; ++i) {
+      BOOST_CHECK(!it_d->second->force_datas[i].f.toVector().isZero());
+    }
   }
 }
 

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -453,7 +453,7 @@ void test_updateForce() {
   crocoddyl::ImpulseModelMultiple::ImpulseDataContainer::iterator it_d, end_d;
   for (it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_d != end_d; ++it_d) {
-    BOOST_CHECK(!it_d->second->f.toVector().isZero());
+    BOOST_CHECK(!it_d->second->force_datas[0].f.toVector().isZero());  // TODO(jfoster): need to modify test logic to go through all forces (even though there should only be one for all impulses)
   }
 }
 

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -453,7 +453,9 @@ void test_updateForce() {
   crocoddyl::ImpulseModelMultiple::ImpulseDataContainer::iterator it_d, end_d;
   for (it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_d != end_d; ++it_d) {
-    BOOST_CHECK(!it_d->second->force_datas[0].f.toVector().isZero());  // TODO(jfoster): need to modify test logic to go through all forces (even though there should only be one for all impulses)
+    for (int i = 0; i < it_d->second->nf; ++i) {
+      BOOST_CHECK(!it_d->second->force_datas[i].f.toVector().isZero());
+    }
   }
 }
 


### PR DESCRIPTION
This PR builds off of the LAAS PR. (Let me know if it's more prudent to set that branch as the base for this PR to see the changes I've made).

* Introduced a notion of a list of forces by repurposing ForceDataAbstract. Now, a vector of ForceDataAbstract is stored in InteractionDataAbstract, which is a new base class for ContactDataAbstract and ImpulseDataAbstract.
* Added a notion of a list of forces in by adding an nf (number of forces) argument to InteractionDataAbstract. This is exposed in ContactDataAbstract, so the kinematic loop can set it to 2, but for all impulses it is hard-coded to 1.
* Pulled a lot of common fields in the contact models and impulse models into the top level ForceDataAbstract.

TODO / Questions:
* I'm not sure how the contact-invdyn changes should work.
* I haven't done any deprecating yet, just done all the logic changes in place to get it working.
* I'm pretty sure that the test_contacts_loop.cpp added in the LAAS PR aren't as thorough as they can be. How can we make these tests meaningful?